### PR TITLE
Alineación de botones extras 5.5.12

### DIFF
--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -53,7 +53,7 @@
 			    "sortable": false,
 			    "render": function ( data, type, full, meta ) {
 			    	var id = data['DT_RowId'];
-			    	var html = '<div class="btn-toolbar btn-toolbar-flex pull-right">';
+			    	var html = '<div class="btn-toolbar btn-toolbar-flex pull-left">';
 			    	@foreach ($botonesExtra as $botonExtra)
 			    		<?php
 $url     = $botonExtra["url"];


### PR DESCRIPTION
Se cambia la alineación de los botones extra, para evitar que se oculten cuando largo de un campo sea mayor al área visible.