### PR TITLE
Optimize the listing query on branch 5.6.bs4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ composer.lock
 .env.php
 .DS_Store
 Thumbs.db
+.phpunit.result.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -109,3 +109,15 @@ Previously the whole table was loaded into memory and filtered/sorted with
 Collection methods, so the cost grew with the total number of rows instead of
 the page size. No public API changed: `setField`, `setWhere`, `setOrderBy` and
 the JSON response shape are the same.
+
+## Tests
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+The suite covers the methods that build the listing query, asserting on the SQL
+and the bindings they produce. It needs Eloquent but never a database server:
+no query is executed. The test tooling is `require-dev` only, so nothing
+changes for consumers of the package.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This package is used to generate cruds.
 
 > **You are on branch `5.6.bs4` - package version `5.6 (bs4 variant)`.**
 
+## Documentation for contributors
+
+| Document | Read it for |
+|---|---|
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | How the package is wired: request lifecycle, field metadata, the listing query |
+| [docs/METHODS.md](docs/METHODS.md) | What every method of `CrudController` does on this branch |
+| [docs/RULES.md](docs/RULES.md) | What you may and may not change: no repurposing methods, behaviour changes go to a new version branch, legacy compatibility first |
+
 ## Requirements
 
 | Requirement | Supported |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,111 @@
 # Crud
-This version uses ``npm`` for dependencies and  ``bootstrap-4`` for styling.  Deletes all css and js from view files.
+
+This package is used to generate cruds.
+
+> **You are on branch `5.6.bs4` - package version `5.6 (bs4 variant)`.**
+
+## Requirements
+
+| Requirement | Supported |
+| ----------- | --------- |
+| PHP         | `>= 7.0` |
+| Laravel     | `>= 5.5` |
+| Frontend    | Bootstrap 4 + jQuery + DataTables 1.x, native date pickers |
+
+Laravel bounds are derived from the framework APIs each branch actually calls,
+since the `composer.json` constraints were never updated:
+
+- `Form::` helpers (`laravelcollective/html`) on `5.0`-`5.4` -> Laravel `5.x` only
+- Package auto-discovery (`extra.laravel.providers`) -> Laravel `>= 5.5`
+- `Storage::disk()->temporaryUrl()` -> Laravel `>= 5.4`
+- `BelongsTo::getOwnerKeyName()` -> Laravel `>= 5.8`
+- `array_except()` (removed in Laravel 6) on `5.3`, `5.4`, `5.7` -> Laravel `<= 5.8`
+- `Relation::getRelationExistenceQuery()` -> Laravel `>= 5.5`
+- `Paginator::withQueryString()` -> Laravel `>= 7.0`
+
+## Compatibility matrix
+
+The branch number is the **package version**, not the Laravel version.
+Every package version lives in its own branch and is released from it.
+
+| Package version | Branch   | PHP      | Laravel     | Status                                 |
+| --------------- | -------- | -------- | ----------- | -------------------------------------- |
+| 8.0             | `master` | `>= 7.2` | `>= 5.8`    | Active                                 |
+| 7.0 Beta        | `7.x`    | `>= 7.2` | `>= 7.0`    | Active (Vue views, paginated response) |
+| 6.0             | `6.0`    | `>= 7.2` | `>= 5.8`    | Maintenance                            |
+| 5.9             | `5.9`    | `>= 7.1` | `>= 6.0`    | Maintenance                            |
+| 5.8             | `5.8`    | `>= 7.1` | `>= 7.0`    | Maintenance                            |
+| 5.7             | `5.7`    | `>= 7.1` | `5.8` only  | Legacy                                 |
+| 5.6             | `5.6`    | `>= 7.0` | `>= 5.5`    | Legacy                                 |
+| 5.5             | `5.5`    | `>= 7.0` | `>= 5.5`    | Legacy                                 |
+| 5.4             | `5.4`    | `>= 5.6` | `5.4 - 5.8` | Legacy                                 |
+| 5.3             | `5.3`    | `>= 5.5` | `5.1 - 5.4` | Legacy                                 |
+| 5.0             | `5.0`    | `>= 5.5` | `5.0 - 5.2` | Archived                               |
+
+## Feature matrix
+
+| Version  | BS  | Datatables | Methods | Views engine | Crypt | Constructor | UTC | Validation     |
+| -------- | --- | ---------- | ------- | ------------ | ----- | ----------- | --- | -------------- |
+| 5.5      | 3   | 1.x        | es      | blade        | yes   | yes         | no  | formvalidation |
+| 5.6      | 4   | 1.x        | es      | blade        | yes   | yes         | no  | formvalidation |
+| 5.9      | 4   | 1.x        | es      | blade        | yes   | no          | no  | laravel        |
+| 6.0      | 4   | 1.x        | en      | blade        | yes   | yes         | no  | formvalidation |
+| 7.0 Beta | 4   | 1.x        | en      | vue          | yes   | yes         | no  | formvalidation |
+| 8.0      | 4/5 | 2.x        | en      | blade        | no    | no          | yes | laravel        |
+
+## Installation
+
+```bash
+composer require csgt/crud:^5.6
+```
+
+## Usage
+
+Create a controller that extends `CrudController` and describe the CRUD in
+`__construct()`:
+
+```php
+use Csgt\Crud\CrudController;
+
+class ClientesController extends CrudController
+{
+    public function __construct()
+    {
+        $this->setModelo(new \App\Cliente);
+        $this->setTitulo('Clientes');
+
+        $this->setCampo(['nombre' => 'Nombre', 'campo' => 'nombre']);
+        $this->setCampo(['nombre' => 'Pais', 'campo' => 'pais.nombre', 'isforeign' => true]);
+
+        $this->setPermisos(['add' => true, 'edit' => true, 'delete' => true]);
+    }
+}
+```
+
+Then register the route:
+
+```php
+Route::resource('clientes', 'ClientesController');
+```
+
+## About this branch
+
+`5.6.bs4` is branch `5.6` with the Bootstrap 4 look, reworked date/datetime/time
+pickers and UTC handling. It is not published as its own package version.
+
+## Listing performance
+
+The `data()` endpoint resolves **search, ordering and pagination in the
+database**:
+
+- The DataTables global search becomes a `WHERE ... LIKE` clause, and relation
+  columns are matched through `whereHas`.
+- Ordering by a relation column uses a correlated subquery instead of sorting
+  in memory.
+- Only the requested page is fetched (`offset` + `limit`).
+- `multi` fields are eager loaded, removing the N+1 query per row.
+
+Previously the whole table was loaded into memory and filtered/sorted with
+Collection methods, so the cost grew with the total number of rows instead of
+the page size. No public API changed: `setField`, `setWhere`, `setOrderBy` and
+the JSON response shape are the same.

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,18 @@
                 "Csgt\\Crud\\CrudServiceProvider"
             ]
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6 || ^10.5",
+        "illuminate/database": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/routing": "^8.0 || ^9.0 || ^10.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Csgt\\Crud\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,220 @@
+# Architecture
+
+Branch `5.6.bs4` — package version `5.6 (bs4 variant)`. See `README.md` for the
+PHP and Laravel bounds of this branch, `METHODS.md` for the method reference
+and `RULES.md` for what you are allowed to change.
+
+---
+
+## What the package does
+
+You declare a CRUD by extending `CrudController` and describing an Eloquent
+model plus a list of fields. From that declaration the package renders the
+listing, serves it to DataTables over AJAX, renders the edit/create form,
+validates and persists the input, and registers the routes.
+
+There is no code generation at runtime: one controller subclass plus one route
+line is a full CRUD.
+
+**This branch's public API is Spanish**, same as `5.6`: `setModelo()`,
+`setCampo()` with the keys `campo`/`nombre`/`tipo`, `setTitulo()`,
+`setPermisos()`. This branch is `5.6` with the Bootstrap 4 look, reworked
+date/datetime/time pickers, UTC handling on fields, and it is **not published
+as its own package version** (see `README.md`, "About this branch").
+
+## File map
+
+| File | Role |
+|---|---|
+| `src/CrudController.php` | Everything: lifecycle actions, query building, field metadata, setters |
+| `src/CrudServiceProvider.php` | Registers views, translations, the `make:crud` command, and swaps the resource registrar |
+| `src/ResourceRegistrar.php` | Extends Laravel's registrar so `Route::resource` also creates the `data` and `detail` routes |
+| `src/Console/MakeCrudCommand.php` | `php artisan make:crud` scaffolding, template in `src/Console/stubs/crud.stub` |
+| `src/resources/views/index.blade.php` | Listing: Bootstrap 4 + DataTables config (built server-side in `index()`), column renderers, the native DataTables search box |
+| `src/resources/views/edit.blade.php` | Edit/create form, one input per field type, native date/datetime/time pickers |
+| `src/resources/lang/{en,es}/crud.php` | All user-facing strings |
+| `src/config/csgtcrud.php` | Package config |
+| `tests/` | PHPUnit suite over the query-building methods |
+
+## Request lifecycle
+
+```
+Route::resource('clientes', ClientesController::class)
+        │
+        │  ResourceRegistrar adds two routes to the seven standard ones:
+        │      POST clientes/data          -> data()
+        │      GET  clientes/{id}/detail   -> detail()   (not implemented on
+        │                                                 this branch; declaring
+        │                                                 it is up to your
+        │                                                 controller)
+        ▼
+GET /clientes ──────────► index()
+                          │ builds the column metadata AND the full DataTables
+                          │ `options` array (ajax url, language strings, order,
+                          │ buttons) in PHP
+                          └─► view csgtcrud::index
+                                  │ DataTables boots with serverSide: true
+                                  ▼
+                        POST /clientes/data ──────► data()
+                                  │ builds ONE query: select, eager loads,
+                                  │ joins, fixed wheres, global search, order,
+                                  │ offset/limit
+                                  └─► JSON { draw, recordsTotal,
+                                             recordsFiltered, data[] }
+
+GET /clientes/create ───► create() ─► view csgtcrud::edit (data = null)
+GET /clientes/{id}/edit ► edit($id) ─► view csgtcrud::edit
+POST /clientes ─────────► store() ─► update($id = 0)
+PUT  /clientes/{id} ────► update($id)
+DELETE /clientes/{id} ──► destroy($id)
+```
+
+`CrudController` itself declares no constructor: the field declaration lives in
+`__construct()` of your own subclass (`setModelo()`, `setCampo()`, ...), which
+Laravel calls before any action runs, so the fields are always in place before
+an action reads them.
+
+Record ids are **always** encrypted/decrypted with `Crypt::encrypt()` /
+`Crypt::decrypt()` on this branch (`show()`, `edit()`, `update()`, `destroy()`,
+`data()`'s `DT_RowId`) — there is no `csgtcrud.usar_encripcion` config toggle
+here, unlike `5.6` and `5.7`.
+
+## Field metadata
+
+`setCampo()` is the heart of the package. Each call validates the incoming keys
+and normalises them into one array with a fixed shape, appended to `$campos`:
+
+```php
+[
+  'campo'      => 'pais.nombre AS pais_nombre',  // as declared
+  'nombre'     => 'Pais',                        // column header
+  'alias'      => 'pais__nombre',                // safe key for the JSON/DOM
+  'campoReal'  => 'nombre',                       // column without the relation
+  'tipo'       => 'string',                       // drives rendering and casting
+  'show'       => true,                           // appears in the listing
+  'editable'   => true,                           // appears in the form
+  'isforeign'  => true,                           // resolve through a relation
+  'filedisk'   => 'local',                        // securefile / file storage disk
+  'utc'        => false,                          // date/datetime/time UTC handling
+  'searchable' => true,
+  ...                                             // default, class, decimales,
+]                                                 // filepath, target, ...
+```
+
+Compared to `5.6`, this branch's `setCampo()` additionally accepts `filedisk`
+and adds `time` to the list of allowed types (`string`, `multi`, `numeric`,
+`date`, `datetime`, `time`, `bool`, `combobox`, `password`, `enum`, `file`,
+`image`, `textarea`, `url`, `summernote`, `securefile`), and `securefile` is
+fully wired up: `update()` uploads the file to `filedisk`/`filepath` and
+deletes the previous one, which `5.6` does not do.
+
+Three shapes of `campo` exist, and most of the query code branches on which one
+it is:
+
+| Shape | Example | Resolved by |
+|---|---|---|
+| local column | `nombre` | `select` on the model's table |
+| relation column | `pais.nombre AS pais_nombre` (`isforeign => true`) | eager load + `whereHas` + correlated subquery for ordering |
+| raw expression | `CONCAT(nombre, id) AS composed` | `DB::raw` in the select, `whereRaw`/`orderByRaw` elsewhere |
+| multi relation | `tags` (`tipo => 'multi'`) | `belongsToMany`, eager loaded per page |
+
+The `getCamposShow()` / `getCamposShowMine()` / `getCamposShowForeign()` /
+`getCamposShowMulti()` / `getCamposOrden()` helpers are just filters over that
+list; see `METHODS.md`. Unlike `5.6`, this branch does have a dedicated
+`getCamposShowMulti()` helper — `5.6` computes that list inline instead.
+
+## The listing query
+
+`data()` builds a single query and never materialises more than one page:
+
+```
+$this->modelo->newQuery()
+   ├── select( local fields + raw expressions )          getSelect + getCamposShowMine
+   ├── with( relation => fn($q) => addSelect(...) )      getCamposShowForeign
+   ├── addSelect( primary key AS ___id___ )
+   ├── leftJoin(...)                                     setLeftJoin
+   ├── where / whereIn / whereRaw                        setWhere*, fixed filters
+   │
+   ├── recordsTotal = (clone $query)->count()
+   │
+   ├── applySearchToQuery( DataTables global search )    only when non-empty
+   ├── recordsFiltered = (clone $query)->count()         only if search applied
+   │
+   ├── applyOrderToQuery( DataTables order )             plain / raw / subquery
+   ├── offset(start)->limit(length)->get()               ONE page
+   └── $items->load( multi relations )                   one extra query, no N+1
+```
+
+The rendering loop then walks `getCamposOrden()` per row and pulls each value:
+the primary key becomes `DT_RowId` (encrypted), relation columns are read with
+`data_get`, and `securefile` fields are turned into temporary URLs. Unlike
+`5.6`, this branch does not implode `multi` values into the row output —
+`getCamposShowMulti()`/`multiColumns` is computed but its result is not read
+into `$cols` in `data()`'s render loop, only used to build `$multiRelations`
+for the eager load.
+
+Two invariants hold the performance in place:
+
+1. **Nothing is filtered or sorted in memory.** No `->get()` before the
+   pagination, no Collection `filter`/`sortBy`/`splice`.
+2. **No query inside the row loop.** Anything a row needs is eager loaded before
+   the loop starts.
+
+`setJoin()` records a relation name into `$this->joins`, but `data()` never
+reads `$this->joins` — only `$this->leftJoins` (populated by `setLeftJoin()`)
+is applied to the query. Calling `setJoin()` on this branch has no effect on
+the listing.
+
+## Global search
+
+This branch has **no per-column filters**. The DataTables global search box
+(native, rendered by DataTables itself, not a custom view element) sends its
+value as `search.value` in the AJAX request. When non-empty, `data()` calls
+`applySearchToQuery($query, $search['value'], $columns, $foreigns)`, which
+wraps the whole thing in one grouped `where`:
+
+- every local shown column (`getCamposShowMine()`) is matched with
+  `orWhereRaw('LOWER(column) LIKE ?', [...])`, case-insensitively
+- every relation grouped by `getCamposShowForeign()` is matched with
+  `orWhereHas($relation, ...)`, itself matching any of that relation's shown
+  columns
+
+The `___id___` alias is skipped. There is no `getFilterColumns()` and no
+`filters[]` payload on this branch — the listing view has no filter-row UI at
+all, it relies entirely on DataTables' own global search input.
+
+## Ordering
+
+DataTables sends column indices; `getCamposOrden()` maps them back to declared
+fields. Then:
+
+- a plain column → `orderBy`
+- a raw expression → `orderByRaw`, so it is not quoted as an identifier
+- a relation column → a correlated subquery built from
+  `getRelationExistenceQuery()`, so the database sorts the page
+- an unknown relation → falls back to a plain `orderBy`, never throws
+
+`setOrderBy()` feeds `$this->orders`, which `index()` turns directly into the
+DataTables `options['order']` array (`foreach ($this->orders as $col => $order)
+{ $options['order'][] = [$col, $order]; }`), so on this branch the default
+sort order is baked into the DataTables initialisation options rather than
+only rendered as a hint for the view to consume.
+
+## Persistence
+
+`store()` delegates to `update($id = 0)`, so one method handles both.
+`update()` first builds Laravel validation `$rules` from every editable
+field's `reglas` and calls `$request->validate($rules)` — a validation step
+`5.6` and `5.7` do not have. It then strips `noGuardar` fields with
+`Illuminate\Support\Arr::except()`, merges `camposHidden`, and per field type:
+parses dates with `Carbon::createFromFormat()`, moves `file`/`image` uploads,
+puts `securefile` uploads on their `filedisk` and deletes the previous one,
+and detaches/attaches `multi` relations. There is no `bool` cast on this
+branch.
+
+## Extending
+
+The intended extension point is your own subclass: declare fields and filters
+in `__construct()`, and override a lifecycle action only when you must, calling
+`parent::` where possible. The private helpers are private on purpose — see
+`RULES.md` before changing any of them.

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -1,0 +1,107 @@
+# Method reference
+
+Branch `5.6.bs4` — package version `5.6 (bs4 variant)`. Every method of
+`Csgt\Crud\CrudController` as it exists on this branch. See `ARCHITECTURE.md`
+for how they fit together and `RULES.md` before changing any of them.
+
+Signatures are copied from the source. **Public methods are contract**: their
+name, signature and observable behaviour cannot change on this branch. This
+branch's API is Spanish (`setModelo`, `setCampo`, `setTitulo`, `setPermisos`,
+`generarBreadcrumb`, ...), same as `5.6`.
+
+---
+
+## Lifecycle actions
+
+Routed by `Route::resource` (the package's `ResourceRegistrar` adds `data` and
+`detail` to the standard seven).
+
+| Method | Route | Does |
+|---|---|---|
+| `index(Request $request)` | `GET /resource` | Renders `csgtcrud::index` with the column metadata, permissions, breadcrumb, extra buttons, and the full DataTables `options` array (ajax url, language strings, default order, export buttons) built in PHP. No query is run here; the rows arrive later over AJAX. |
+| `show(Request $request, $aId)` | `GET /resource/{id}` | Finds the record (`$aId` always decrypted with `Crypt::decrypt()`) and returns it as JSON when the request expects JSON. |
+| `edit(Request $request, $aId)` | `GET /resource/{id}/edit` | Renders `csgtcrud::edit` for an existing record: editable fields, combo options, breadcrumb, query string. |
+| `create(Request $request)` | `GET /resource/create` | Renders `csgtcrud::edit` directly, with `$data = null`; it does not delegate to `edit()`. |
+| `store(Request $request)` | `POST /resource` | Delegates to `update($request, 0)`. |
+| `update(Request $request, $aId)` | `PUT /resource/{id}` | Creates when `$aId === 0`, updates otherwise. Validates the request with rules built from each editable field's `reglas`, strips `noGuardar` fields with `Arr::except()`, merges `camposHidden`, normalises each value by field type (dates via `Carbon::createFromFormat()`, `file`/`image` moved, `securefile` put on its `filedisk` and the previous one deleted), saves, then detaches/attaches the `multi` relations. Returns JSON (`{data, redirect}`) or a redirect. |
+| `destroy(Request $request, $aId)` | `DELETE /resource/{id}` | Deletes the record, flashes the result message and redirects. |
+
+## Listing query helpers
+
+All private. Called from `data()`, and covered by `tests/CrudControllerTest.php`.
+
+| Method | Does | Notes |
+|---|---|---|
+| `applySearchToQuery($query, $searchValue, $columns, $foreigns)` | Applies the DataTables global search as one grouped `where`: `orWhereRaw('LOWER(column) LIKE ?', ...)` for every local shown column, `orWhereHas($relation, ...)` for every relation. | Replaces `applyFiltersToQuery`/`applyColumnFilter` from `5.6`/`5.7` — there is no per-column filter path on this branch. |
+| `applyOrderToQuery($query, $columnName, $direction)` | Orders in the database: `orderBy` for a plain column, `orderByRaw` for an expression, and a correlated subquery for a relation column. | Falls back to a plain `orderBy` when the relation does not exist on the model, so a stale declaration cannot throw. |
+| `stripAlias($field)` | Returns the expression without its ` AS alias` suffix. | `AS` is only valid in a `SELECT`; leaving it in a `WHERE`/`ORDER BY` produces invalid SQL. |
+| `qualifyRelatedColumn($relatedModel, $column)` | Prefixes the related table only when the column is a plain identifier. | Expressions, already-qualified columns and aliases are returned untouched. |
+| `getSelect($aCampos)` | Maps the given fields to `DB::raw` expressions for the `select`. | Raw on purpose: a field may be an expression. |
+
+## Field metadata helpers
+
+Private filters over `$campos`, the list built by `setCampo()`.
+
+| Method | Returns |
+|---|---|
+| `getCamposShow()` | Every field with `show => true`, in declaration order. |
+| `getCamposShowMine()` | Shown fields that live on the model's own table: not `multi`, and not a relation column. These go into the `select`. |
+| `getCamposShowForeign()` | Shown relation columns grouped by relation name, in the shape `data()` consumes to build the eager loads and the global search's `whereHas`. |
+| `getCamposShowMulti()` | Shown fields of type `multi`, used to build the eager-loaded relations. Unlike `5.6`, this is a dedicated method rather than an inline filter. |
+| `getCamposEditMine()` | Fields with `editable => true` whose `campo` has no `.`; drives the edit form and the `update()` validation rules. |
+| `getCamposEdit()` | Every field with `editable => true`. |
+| `getCamposOrden()` | The declared field names in listing order with `___id___` appended; maps a DataTables column index back to a field. |
+
+There is no `getFilterColumns()` on this branch: without per-column filters
+there is no filter `<select>` to feed.
+
+## Rendering helpers
+
+| Method | Visibility | Does |
+|---|---|---|
+| `generarBreadcrumb($aTipo, $aUrl = '')` | public | Builds the breadcrumb HTML for `index`, `edit` or `create`. |
+| `mostrarBreadcrumb($aBool)` | public | Toggles the breadcrumb. |
+| `fillCombos($aCampos)` | private | Resolves the option list of every `combobox` and `multi` field for the form. |
+| `getTemplate()` | public | The Blade layout the views extend. |
+| `getTitulo()` | public | The configured title. |
+| `downLevel($aPath)` | private | Drops the last segment of a path; used to build the redirect and breadcrumb URLs. |
+| `getQueryString($request)` | private | The current query string, preserved across redirects so the page survives a save. |
+
+## Setters — the declaration API
+
+Called from your controller's `__construct()`. This is the public surface most
+applications depend on; treat every signature as frozen.
+
+| Method | Purpose |
+|---|---|
+| `setModelo($aModelo)` | The Eloquent model the CRUD is built on. Required. |
+| `setCampo($aParams)` | Declares one field. Accepts `campo`, `nombre`, `editable`, `show`, `tipo`, `class`, `default`, `reglas`, `reglasmensaje`, `decimales`, `collection`, `enumarray`, `filepath`, `filewidth`, `fileheight`, `filedisk`, `target`, `isforeign`, `utc`. Types (`tipo`): `string`, `multi`, `numeric`, `date`, `datetime`, `time`, `bool`, `combobox`, `password`, `enum`, `file`, `image`, `textarea`, `url`, `summernote`, `securefile`. Rejects unknown keys. Adds `filedisk` and the `time` type compared to `5.6`. |
+| `setLayout($aLayout)` | Blade layout to extend. |
+| `setTitulo($aTitulo)` | Listing title. |
+| `setPermisos($aFuncionPermisos, $aModulo = false)` | `add` / `edit` / `delete` flags. |
+| `setWhere($aColumna, $aOperador, $aValor = null)` | Fixed `WHERE` on the listing. Two-argument form means equality. |
+| `setWhereIn($aColumna, $aArray)` | Fixed `WHERE IN`. |
+| `setWhereRaw($aStatement)` | Fixed raw `WHERE`. |
+| `setJoin($aRelation)` | Recorded into `$this->joins`, but `data()` never reads it — has no observable effect on the listing. |
+| `setLeftJoin($aTabla, $aCol1, $aOperador, $aCol2)` | Extra `leftJoin` applied to the listing query. |
+| `setOrderBy($aParams)` | Default order, turned directly into the DataTables `options['order']` array by `index()`. |
+| `setPerPage($aCuantos)` | Rows per page (default 50). |
+| `setHidden($aParams)` | Values injected on save without being rendered. Keys: `campo`, `valor`. |
+| `setNoGuardar($aCampo)` | Request keys never persisted (`_token` is always ignored). |
+| `setBreadcrumb($aArray)` | Custom breadcrumb trail. |
+| `setBotonExtra($aParams)` | Extra button per row (`url`, `titulo`, `target`, `icon`, `class`, `confirm`, `confirmmessage`). |
+| `setAccionExtra($aParams)` | Extra action next to the Add button (`url`, `titulo`, `target`). |
+| `setResponsive($aResponsive)` | Wraps the table in `table-responsive`. |
+
+## Where the tests live
+
+`tests/CrudControllerTest.php` covers the listing query helpers and the field
+metadata helpers by asserting the SQL and the bindings they produce, with the
+private methods reached through the reflection helpers in `tests/TestCase.php`.
+It specifically tests `applySearchToQuery` (local columns, foreign columns via
+`whereHas`, and that the `___id___` alias is skipped) rather than
+`applyFiltersToQuery`/`applyColumnFilter`, which do not exist on this branch.
+
+Not covered, and why: the lifecycle actions need a booted application (`view()`,
+`config()`, `redirect()`, a real `Request`), which the suite deliberately avoids
+so it can run without a database server or a Laravel app.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,0 +1,124 @@
+# Rules for working on this package
+
+These rules apply to every branch of `csgt/crud`. They exist because this
+package is installed by long-lived applications that pin a branch and rarely
+upgrade: a change that looks harmless here becomes a broken listing in a project
+nobody has touched in three years.
+
+Read `ARCHITECTURE.md` for how the package is wired and `METHODS.md` for what
+each method does before changing anything.
+
+---
+
+## 1. Never repurpose an existing method
+
+A public method that already exists keeps its name, its signature and its
+observable behaviour. Do not:
+
+- change what a method returns or the shape of what it returns
+- add a required parameter, or reorder parameters
+- rename a method, a field key, a config key, a translation key or a view
+  variable
+- change the JSON shape returned by `data()`
+- silently change the meaning of an option (for example making a flag opt-out
+  when it used to be opt-in)
+
+If the new behaviour cannot coexist with the old one, it does not belong in this
+branch. Open it on a new version branch instead — see rule 2.
+
+**Allowed without a new version:** fixing a method that is provably broken (it
+throws, produces invalid SQL, or contradicts its own documented purpose), adding
+a new optional parameter with a default that preserves the current result, and
+adding a brand new method.
+
+## 2. A behaviour change means a new version, not an edit
+
+The branch number is the **package version**, not the Laravel version. Each
+version lives in its own branch and is released from it, so the upgrade path for
+an application is "move to another branch", which is a decision its maintainer
+takes deliberately.
+
+This branch is `5.6.bs4`, a Bootstrap 4 variant of `5.6` that is **not
+published as its own package version** (see `README.md`). It still follows the
+same rule: a change here that is not a pure visual/BS4 port of a `5.6` change
+does not belong on this branch either.
+
+Therefore:
+
+- a breaking change starts a new branch, cut from the newest branch that has the
+  behaviour you want to keep
+- a fix or a backward-compatible addition goes on the branch it belongs to, and
+  is ported to the newer branches that share the same code shape
+- never rewrite history or force-push a released branch
+- the compatibility matrix in `README.md` is part of the change: if you add a
+  branch, or the PHP/Laravel floor of a branch moves, update the matrix in every
+  branch's README
+
+## 3. Legacy compatibility is the priority
+
+When two implementations both work, take the one that keeps working on the
+oldest PHP and Laravel this branch supports. Check `README.md` for the exact
+bounds of the branch you are on, and before using a framework API, confirm it
+exists in the lowest supported Laravel version.
+
+This branch's floor is PHP `>= 7.0`, Laravel `>= 5.5` (see `README.md`).
+Concrete traps that have already bitten this package:
+
+| Do not use on this branch | Because | Use instead |
+|---|---|---|
+| `[$a, $b] = $array` | requires PHP 7.1+, above this branch's PHP 7.0 floor | `list($a, $b) = $array` or index access |
+| `$query->orderBy($builder, ...)` | Laravel 6+ | `orderByRaw($sub->toSql(), $sub->getBindings())` |
+| `Relation::getRelationExistenceQuery()` | Laravel 5.5+, already relied on by `applyOrderToQuery()` on this branch — this is exactly this branch's Laravel floor, do not lower it further | guard any *new* use with `method_exists()` and fall back |
+| `Model::qualifyColumn()` | Laravel 5.5+ | `$model->getTable().'.'.$column` |
+| `Arr::except()` | Laravel 5.5+ (`Illuminate\Support\Arr`) — already used on this branch for the `multi` fields and for stripping `noGuardar`, so it is safe here, but do not backport it to a branch below Laravel 5.5 | the global `array_except()` on branches whose floor predates `Arr::` |
+| `str_slug()` / other removed global helpers | removed in Laravel 6 | the `Str::`/`Arr::` facade equivalents, since this branch's floor already allows them |
+
+Never widen or tighten the `require` block of `composer.json` to make your
+change fit. Dev-only tooling belongs in `require-dev`, where it cannot affect an
+application that installs the package.
+
+## 4. Every change to the query pipeline needs a test
+
+The listing query is the part of this package that silently breaks. Anything
+touching `data()` or its helpers ships with a test in `tests/` asserting the
+generated SQL and bindings.
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+The suite must run without a database server: assert on `toSql()` and
+`getBindings()`, never execute the query. If a test fails, first check whether
+the source really behaves differently on this branch — adjust the source or the
+expectation deliberately, never weaken an assertion to get to green.
+
+Filtering, ordering and pagination happen **in the database**. Do not reintroduce
+`->get()` followed by Collection `filter`/`sortBy`/`splice`: that loads the whole
+table into memory and the cost grows with the table instead of the page.
+
+## 5. User-facing text goes through the translation files
+
+No hardcoded Spanish or English in views or controllers. Add the key to both
+`src/resources/lang/en/crud.php` and `src/resources/lang/es/crud.php`, and reach
+it with `trans('csgtcrud::crud.key')`.
+
+## 6. Conventions
+
+- Match the file you are editing: indentation, brace style and alignment differ
+  between branches, and a reformatting diff hides the real change.
+- Commit messages and PR titles/bodies in English, in the imperative mood, with
+  a body explaining *why* when it is not obvious.
+- One concern per commit. A port, a test and a doc update are three commits.
+- Do not commit `composer.lock` or `vendor/`; both are ignored.
+
+## 7. Checklist before opening a PR
+
+- [ ] No existing method changed name, signature or observable behaviour (rule 1)
+- [ ] If behaviour had to change, it is on a new version branch (rule 2)
+- [ ] No API newer than this branch's supported Laravel/PHP floor (rule 3)
+- [ ] `vendor/bin/phpunit` is green, and the change is covered (rule 4)
+- [ ] New strings exist in both language files (rule 5)
+- [ ] `composer.json` `require` untouched
+- [ ] The change is ported to the other branches that share the same code shape,
+      or the PR says explicitly why it is not

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/CrudController.php
+++ b/src/CrudController.php
@@ -304,7 +304,8 @@ class CrudController extends BaseController
         $recordsTotal    = 0;
 
         //Se obtienen los campos a mostrar desde el modelo
-        $data = $this->modelo->select($campos);
+        $data = $this->modelo->newQuery();
+        $data->select($campos);
 
         $foreigns = $this->getCamposShowForeign();
         foreach ($foreigns as $relation => $fields) {
@@ -346,52 +347,50 @@ class CrudController extends BaseController
             $data->whereRaw($whereRaw);
         }
 
-        $data = $data->get();
         //Obtenemos la cantidad de registros antes de filtrar
-        $recordsTotal = $data->count();
+        $recordsTotal = (clone $data)->count();
 
-        //Filtramos con el campo de la vista
+        //Filtramos con el campo de la vista, directamente en la base de datos
         if ($search['value'] != '') {
-            if ($recordsTotal > 0) {
-                $data = $data->filter(function ($item) use ($search) {
-                    $result = false;
-                    foreach ($item->getAttributes() as $column) {
-                        $result = $result || stristr(strtoupper($column), strtoupper($search['value']));
-                    }
-                    $relations = $item->getRelations();
-                    foreach ($relations as $relation) {
-                        if ($relation && method_exists($relation, 'getAttributes')) {
-                            foreach ($relation->getAttributes() as $column) {
-                                $result = $result || stristr(strtoupper($column), strtoupper($search['value']));
-                            }
-                        }
-                    }
-
-                    return $result;
-                });
-            }
+            $this->applySearchToQuery($data, $search['value'], $columns, $foreigns);
         }
 
         //Obtenemos la cantidad de registros luego de haber filtrado
-        $recordsFiltered = $data->count();
+        $recordsFiltered = $search['value'] != '' ? (clone $data)->count() : $recordsTotal;
 
-        //Ahora order by
+        //Ahora order by, tambien en la base de datos
         $ordenColumnas = $this->getCamposOrden();
         if ($orders) {
             foreach ($orders as $order) {
-                if ($order['dir'] == 'asc') {
-                    $data = $data->sortBy($ordenColumnas[$order['column']], SORT_NATURAL | SORT_FLAG_CASE);
+                $columnName = isset($ordenColumnas[$order['column']]) ? $ordenColumnas[$order['column']] : null;
+                if ($columnName === null) {
+                    continue;
+                }
+
+                $direction = strtolower($order['dir']) == 'desc' ? 'desc' : 'asc';
+
+                if ($columnName == $this->uniqueid) {
+                    $data->orderBy($this->modelo->getTable() . '.' . $this->modelo->getKeyName(), $direction);
                 } else {
-                    $data = $data->sortByDesc($ordenColumnas[$order['column']], SORT_NATURAL | SORT_FLAG_CASE);
+                    $this->applyOrderToQuery($data, $columnName, $direction);
                 }
             }
         }
 
-        //Filtramos los registros y obtenemos el arreglo con la data
+        //Paginamos en la base de datos y obtenemos unicamente la pagina solicitada
         $items = $data
-            ->splice($request->start)
-            ->take($request->length)
-            ->toArray();
+            ->offset((int) $request->start)
+            ->limit((int) $request->length)
+            ->get();
+
+        //Los campos multi se cargan de una sola vez para evitar N+1
+        $multiRelations = array_values(array_unique(array_filter(array_map(function ($campo) {
+            return $campo['tipo'] == 'multi' ? $campo['campo'] : null;
+        }, $this->campos))));
+
+        if (!empty($multiRelations)) {
+            $items->load($multiRelations);
+        }
 
         $arr = [];
         foreach ($items as $item) {
@@ -435,19 +434,15 @@ class CrudController extends BaseController
                     $lastItem = Crypt::encrypt($item[$colName]);
                 } elseif ($esRelacion) {
                     //Se chequea si el restultado de la relaci'on es de uno a uno o de uno a muchos
-                    if ($item[$relationName]) {
-                        if (array_key_exists(0, $item[$relationName])) {
-                            $cols[] = $item[$relationName][0][$colName];
-                        } else {
-                            if (array_key_exists($colName, $item[$relationName])) {
-                                $cols[] = $item[$relationName][$colName];
-                            } else {
-                                $cols[] = null;
-                            }
-                        }
-                    } else {
-                        $cols[] = null;
+                    $relation = $item[$relationName];
+
+                    if ($relation instanceof \Illuminate\Support\Collection) {
+                        $relation = $relation->first();
+                    } elseif (is_array($relation) && array_key_exists(0, $relation)) {
+                        $relation = $relation[0];
                     }
+
+                    $cols[] = data_get($relation, $colName);
                 } else {
                     $fullCampo = array_filter($this->campos, function ($campo) use ($colName) {
                         return $campo['campo'] == $colName;
@@ -476,6 +471,117 @@ class CrudController extends BaseController
         }
 
         return response()->json(['draw' => $request->draw, 'recordsTotal' => $recordsTotal, 'recordsFiltered' => $recordsFiltered, 'data' => $arr]);
+    }
+
+    /**
+     * Ordena en la base de datos. Si la columna pertenece a una relacion se ordena
+     * con un subquery correlacionado en lugar de traer toda la tabla a memoria.
+     */
+    private function applyOrderToQuery($query, $columnName, $direction)
+    {
+        $columnName = $this->stripAlias($columnName);
+        $isRelation = strpos($columnName, '.') !== false && strpos($columnName, '"') === false
+        && strpos($columnName, '(') === false;
+
+        if (!$isRelation) {
+            if (strpos($columnName, '(') !== false || strpos($columnName, ' ') !== false) {
+                $query->orderByRaw($columnName . ' ' . $direction);
+            } else {
+                $query->orderBy($columnName, $direction);
+            }
+
+            return;
+        }
+
+        $partes        = explode('.', $columnName, 2);
+        $relationName  = $partes[0];
+        $relatedColumn = $partes[1];
+
+        if (!method_exists($this->modelo, $relationName)) {
+            $query->orderBy($columnName, $direction);
+
+            return;
+        }
+
+        $relation      = $this->modelo->{$relationName}();
+        $relatedModel  = $relation->getRelated();
+        $relationQuery = $relation->getRelationExistenceQuery(
+            $relatedModel->newQuery(),
+            $query
+        )
+            ->select(DB::raw($this->qualifyRelatedColumn($relatedModel, $relatedColumn)))
+            ->limit(1);
+
+        $query->orderByRaw('(' . $relationQuery->toSql() . ') ' . $direction, $relationQuery->getBindings());
+    }
+
+    /**
+     * Devuelve la expresion sin el alias, para poder usarla dentro de un WHERE.
+     */
+    private function stripAlias($field)
+    {
+        $field = trim($field);
+        $pos   = stripos($field, ' as ');
+
+        if ($pos !== false) {
+            $field = trim(substr($field, 0, $pos));
+        }
+
+        return $field;
+    }
+
+    /**
+     * Antepone la tabla a la columna solo cuando es un identificador simple.
+     * Las expresiones (alias, funciones) se dejan intactas.
+     */
+    private function qualifyRelatedColumn($relatedModel, $column)
+    {
+        $column = trim($column);
+
+        if (strpos($column, '(') !== false || strpos($column, ' ') !== false || strpos($column, '.') !== false) {
+            return $column;
+        }
+
+        return $relatedModel->getTable() . '.' . $column;
+    }
+
+    /**
+     * Aplica la busqueda global de DataTables como un WHERE en la base de datos,
+     * incluyendo las columnas de las relaciones via whereHas.
+     */
+    private function applySearchToQuery($query, $searchValue, $columns, $foreigns)
+    {
+        $searchValue = '%' . mb_strtolower(trim($searchValue)) . '%';
+
+        $query->where(function ($searchQuery) use ($searchValue, $columns, $foreigns) {
+            foreach ($columns as $column) {
+                $field = $this->stripAlias($column['campo']);
+                if ($field == '' || $field == $this->uniqueid) {
+                    continue;
+                }
+                $searchQuery->orWhereRaw('LOWER(' . $field . ') LIKE ?', [$searchValue]);
+            }
+
+            foreach ($foreigns as $relation => $relationFields) {
+                if (!method_exists($this->modelo, $relation)) {
+                    continue;
+                }
+
+                $searchQuery->orWhereHas($relation, function ($relationQuery) use ($relationFields, $searchValue) {
+                    $relationQuery->where(function ($relationWhere) use ($relationFields, $searchValue) {
+                        foreach ($relationFields as $fields) {
+                            foreach ($fields as $field) {
+                                $field = $this->stripAlias($field);
+                                if ($field == '') {
+                                    continue;
+                                }
+                                $relationWhere->orWhereRaw('LOWER(' . $field . ') LIKE ?', [$searchValue]);
+                            }
+                        }
+                    });
+                });
+            }
+        });
     }
 
     private function downLevel($aPath)

--- a/tests/CrudControllerTest.php
+++ b/tests/CrudControllerTest.php
@@ -1,0 +1,212 @@
+<?php
+namespace Csgt\Crud\Tests;
+
+use Csgt\Crud\Tests\Fixtures\Client;
+use Csgt\Crud\Tests\Fixtures\ClientsController;
+
+/**
+ * One group of tests per method of CrudController that shapes the listing
+ * query. Everything is asserted on the generated SQL and bindings.
+ */
+class CrudControllerTest extends TestCase
+{
+    protected $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new ClientsController;
+    }
+
+    protected function query()
+    {
+        return Client::query();
+    }
+
+    /*==================== getSelect ====================*/
+
+    public function testGetSelectReturnsOneExpressionPerLocalShownField()
+    {
+        $columns = $this->call($this->controller, 'getCamposShowMine');
+        $select  = $this->call($this->controller, 'getSelect', [$columns]);
+
+        $this->assertCount(count($columns), $select);
+        $this->assertSame(
+            ['name', 'CONCAT(name, id) AS composed'],
+            array_map(function ($expression) {
+                return $expression->getValue(\Illuminate\Database\Capsule\Manager::connection()->getQueryGrammar());
+            }, $select)
+        );
+    }
+
+    /*==================== getCamposShow ====================*/
+
+    public function testGetCamposShowReturnsEveryShownFieldRegardlessOfType()
+    {
+        $fields = array_column($this->call($this->controller, 'getCamposShow'), 'campo');
+
+        $this->assertSame(
+            ['name', 'country.name AS country_name', 'tags', 'CONCAT(name, id) AS composed'],
+            $fields
+        );
+    }
+
+    /*==================== getCamposShowMine ====================*/
+
+    public function testGetCamposShowMineExcludesRelationsAndMultiFields()
+    {
+        $fields = array_column($this->call($this->controller, 'getCamposShowMine'), 'campo');
+
+        $this->assertSame(['name', 'CONCAT(name, id) AS composed'], $fields);
+    }
+
+    /*==================== getCamposShowForeign ====================*/
+
+    public function testGetCamposShowForeignGroupsColumnsByRelation()
+    {
+        $foreigns = $this->call($this->controller, 'getCamposShowForeign');
+
+        $this->assertSame(['country'], array_keys($foreigns));
+        $this->assertSame('name AS country_name', $foreigns['country'][0][0]);
+    }
+
+    /*==================== getCamposShowMulti ====================*/
+
+    public function testGetCamposShowMultiReturnsOnlyMultiFields()
+    {
+        $multi = array_column($this->call($this->controller, 'getCamposShowMulti'), 'campo');
+
+        $this->assertSame(['tags'], $multi);
+    }
+
+    /*==================== getCamposOrden ====================*/
+
+    public function testGetCamposOrdenKeepsColumnOrderAndAppendsTheUniqueId()
+    {
+        $order = $this->call($this->controller, 'getCamposOrden');
+
+        $this->assertSame(
+            ['name', 'country.name AS country_name', 'tags', 'CONCAT(name, id) AS composed', '___id___'],
+            $order
+        );
+    }
+
+    /*==================== stripAlias ====================*/
+
+    public function testStripAliasRemovesTheAliasAndKeepsPlainColumns()
+    {
+        $this->assertSame('country.name', $this->call($this->controller, 'stripAlias', ['country.name AS country_name']));
+        $this->assertSame('name', $this->call($this->controller, 'stripAlias', ['  name  ']));
+        $this->assertSame('CONCAT(a, b)', $this->call($this->controller, 'stripAlias', ['CONCAT(a, b) as composed']));
+    }
+
+    /*==================== qualifyRelatedColumn ====================*/
+
+    public function testQualifyRelatedColumnOnlyPrefixesPlainIdentifiers()
+    {
+        $model = new \Csgt\Crud\Tests\Fixtures\Country;
+
+        $this->assertSame('countries.name', $this->call($this->controller, 'qualifyRelatedColumn', [$model, 'name']));
+        $this->assertSame('CONCAT(a, b)', $this->call($this->controller, 'qualifyRelatedColumn', [$model, 'CONCAT(a, b)']));
+        $this->assertSame('other.name', $this->call($this->controller, 'qualifyRelatedColumn', [$model, 'other.name']));
+    }
+
+    /*==================== applyOrderToQuery ====================*/
+
+    public function testApplyOrderToQueryOrdersALocalColumn()
+    {
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'name', 'desc']);
+
+        $this->assertStringContainsString('order by "name" desc', $query->toSql());
+    }
+
+    public function testApplyOrderToQueryOrdersARawExpressionWithoutQuotingIt()
+    {
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'CONCAT(name, id) AS composed', 'asc']);
+
+        $this->assertStringContainsString('order by CONCAT(name, id) asc', $query->toSql());
+    }
+
+    public function testApplyOrderToQueryOrdersARelationWithACorrelatedSubquery()
+    {
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'country.name AS country_name', 'desc']);
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('order by (select countries.name from "countries"', $sql);
+        $this->assertStringContainsString('"clients"."country_id" = "countries"."id"', $sql);
+        $this->assertStringContainsString('limit 1) desc', $sql);
+        $this->assertStringNotContainsString('country_name', $sql);
+    }
+
+    public function testApplyOrderToQueryFallsBackToAPlainOrderForAnUnknownRelation()
+    {
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'missing.name', 'asc']);
+
+        $this->assertStringContainsString('order by "missing"."name" asc', $query->toSql());
+    }
+
+    /*==================== applySearchToQuery ====================*/
+
+    public function testApplySearchToQueryMatchesLocalColumns()
+    {
+        $columns  = $this->call($this->controller, 'getCamposShowMine');
+        $foreigns = [];
+        $query    = $this->query();
+
+        $this->call($this->controller, 'applySearchToQuery', [$query, 'acme', $columns, $foreigns]);
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('LOWER(name) LIKE ?', $sql);
+        $this->assertStringContainsString('LOWER(CONCAT(name, id)) LIKE ?', $sql);
+        $this->assertSame(['%acme%', '%acme%'], $query->getBindings());
+    }
+
+    public function testApplySearchToQueryMatchesForeignColumnsThroughWhereHas()
+    {
+        $columns  = [];
+        $foreigns = $this->call($this->controller, 'getCamposShowForeign');
+        $query    = $this->query();
+
+        $this->call($this->controller, 'applySearchToQuery', [$query, 'mex', $columns, $foreigns]);
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('exists (select * from "countries"', $sql);
+        $this->assertStringContainsString('LOWER(name) LIKE ?', $sql);
+        $this->assertSame(['%mex%'], $query->getBindings());
+    }
+
+    public function testApplySearchToQueryIgnoresTheUniqueIdColumn()
+    {
+        $columns  = [['campo' => $this->call($this->controller, 'getCamposOrden')[4]]];
+        $foreigns = [];
+        $query    = $this->query();
+
+        $this->call($this->controller, 'applySearchToQuery', [$query, 'acme', $columns, $foreigns]);
+
+        $this->assertStringNotContainsString('where', $query->toSql());
+    }
+
+    /*==================== downLevel ====================*/
+
+    public function testDownLevelRemovesTheLastSegmentOfThePath()
+    {
+        $this->assertSame('clients', $this->call($this->controller, 'downLevel', ['clients/5']));
+        $this->assertSame('', $this->call($this->controller, 'downLevel', ['clients']));
+    }
+
+    /*==================== setCampo ====================*/
+
+    public function testSetCampoBuildsTheDeclaredFields()
+    {
+        $this->assertSame('Clients', $this->controller->getTitulo());
+        $this->assertCount(5, $this->read($this->controller, 'campos'));
+    }
+}

--- a/tests/Fixtures/Client.php
+++ b/tests/Fixtures/Client.php
@@ -1,0 +1,21 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'clients';
+
+    public function country()
+    {
+        return $this->belongsTo(Country::class, 'country_id');
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class, 'client_tag', 'client_id', 'tag_id');
+    }
+}

--- a/tests/Fixtures/ClientsController.php
+++ b/tests/Fixtures/ClientsController.php
@@ -1,0 +1,23 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Csgt\Crud\CrudController;
+
+/**
+ * Minimal controller used by the tests: it declares the same fields a real CRUD
+ * would declare, without touching the framework beyond Eloquent.
+ */
+class ClientsController extends CrudController
+{
+    public function __construct()
+    {
+        $this->setModelo(new Client);
+        $this->setTitulo('Clients');
+
+        $this->setCampo(['campo' => 'name', 'nombre' => 'Name']);
+        $this->setCampo(['campo' => 'country.name AS country_name', 'nombre' => 'Country', 'isforeign' => true]);
+        $this->setCampo(['campo' => 'tags', 'nombre' => 'Tags', 'tipo' => 'multi']);
+        $this->setCampo(['campo' => 'CONCAT(name, id) AS composed', 'nombre' => 'Composed']);
+        $this->setCampo(['campo' => 'secret', 'nombre' => 'Secret', 'show' => false, 'editable' => true]);
+    }
+}

--- a/tests/Fixtures/Country.php
+++ b/tests/Fixtures/Country.php
@@ -1,0 +1,11 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Country extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'countries';
+}

--- a/tests/Fixtures/Tag.php
+++ b/tests/Fixtures/Tag.php
@@ -1,0 +1,11 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'tags';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,79 @@
+<?php
+namespace Csgt\Crud\Tests;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use ReflectionMethod;
+
+/**
+ * Base for the package tests.
+ *
+ * The suite asserts on the SQL and the bindings each method builds, so it needs
+ * Eloquent and a connection, but never a live database server: no query is ever
+ * executed. That keeps the suite runnable anywhere PHP and composer are.
+ */
+abstract class TestCase extends BaseTestCase
+{
+    protected static $capsule;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (static::$capsule) {
+            return;
+        }
+
+        //The package source uses the root aliases a Laravel app registers.
+        foreach (['DB' => 'Illuminate\\Support\\Facades\\DB', 'Storage' => 'Illuminate\\Support\\Facades\\Storage'] as $alias => $facade) {
+            if (!class_exists($alias, false)) {
+                class_alias($facade, $alias);
+            }
+        }
+
+        $container = new Container;
+
+        static::$capsule = new Capsule($container);
+        static::$capsule->addConnection([
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+        static::$capsule->setAsGlobal();
+        static::$capsule->bootEloquent();
+
+        $container->instance('db', static::$capsule->getDatabaseManager());
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+    }
+
+    /**
+     * Calls a private or protected method of the controller under test.
+     */
+    protected function call($object, $method, array $arguments = [])
+    {
+        $reflection = new ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($object, $arguments);
+    }
+
+    /**
+     * Reads a private or protected property of the controller under test.
+     */
+    protected function read($object, $property)
+    {
+        $class = new \ReflectionClass($object);
+
+        while (!$class->hasProperty($property) && $class->getParentClass()) {
+            $class = $class->getParentClass();
+        }
+
+        $reflection = $class->getProperty($property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($object);
+    }
+}


### PR DESCRIPTION
## What

1. **Listing optimization** — ports `optimization: move filter and order logic to the query` and `fix: order by foreign relation` from branch `5.9`.
2. **Tests** — adds a PHPUnit suite covering the methods that build the listing query.
3. **README** — documents the PHP and Laravel versions this branch supports.

## Why

`data()` fetched every row of the table and then filtered, sorted and sliced it
in memory with Collection methods, so the cost of a page grew with the size of
the table.

## How

- The global search becomes a `WHERE ... LIKE` clause; relation columns are
  matched with `whereHas`.
- Ordering by a relation column uses a correlated subquery instead of `sortBy`.
- Only the requested page is read, with `offset`/`limit`.
- Aliased expressions (`col AS alias`) are stripped before being used inside
  `WHERE`/`ORDER BY`.

## Not included: the per-column filters

`feat: search by column, multifilter` was **not** ported here on purpose. This
branch is a Bootstrap 4 variant of `5.6` whose last change is from 2022, while
`5.6` itself is still being updated, so the filter UI was ported to `5.6`
instead. Say the word if you want it here too.

## Testing

`composer install && vendor/bin/phpunit` — 17 tests, 32 assertions, green.

The suite asserts on the SQL and the bindings each method produces and needs no
database server. The test tooling is `require-dev` only.

A manual pass over one listing per project is still recommended before tagging
a release, since the suite does not assert against live rows.
