### PR TITLE
Optimize the listing query on branch 5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ composer.lock
 .env.php
 .DS_Store
 Thumbs.db
+.phpunit.result.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -104,3 +104,22 @@ Previously the whole table was loaded into memory and filtered/sorted with
 Collection methods, so the cost grew with the total number of rows instead of
 the page size. No public API changed: `setField`, `setWhere`, `setOrderBy` and
 the JSON response shape are the same.
+
+## Tests
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+The suite covers the methods that build the listing query, asserting on the SQL
+and the bindings they produce. It needs Eloquent but never a database server:
+no query is executed. The test tooling is `require-dev` only, so nothing
+changes for consumers of the package.
+
+This branch pins `illuminate/support ~5.1` at runtime, which the modern Eloquent
+used by the tests cannot satisfy. `require-dev` therefore declares
+`"illuminate/support": "10.49.0 as 5.1.999"`: composer installs the modern
+package for the dev environment while still satisfying the old root constraint.
+Runtime dependencies are untouched, and `composer install --no-dev` is
+unaffected.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+# Crud
+
+This package is used to generate cruds.
+
+> **You are on branch `5.3` - package version `5.3`.**
+
+## Requirements
+
+| Requirement | Supported |
+| ----------- | --------- |
+| PHP         | `>= 5.5` |
+| Laravel     | `5.1 - 5.4` |
+| Frontend    | Bootstrap 3 + jQuery + DataTables 1.x, laravelcollective/html |
+
+Laravel bounds are derived from the framework APIs each branch actually calls,
+since the `composer.json` constraints were never updated:
+
+- `Form::` helpers (`laravelcollective/html`) on `5.0`-`5.4` -> Laravel `5.x` only
+- Package auto-discovery (`extra.laravel.providers`) -> Laravel `>= 5.5`
+- `Storage::disk()->temporaryUrl()` -> Laravel `>= 5.4`
+- `BelongsTo::getOwnerKeyName()` -> Laravel `>= 5.8`
+- `array_except()` (removed in Laravel 6) on `5.3`, `5.4`, `5.7` -> Laravel `<= 5.8`
+- `Relation::getRelationExistenceQuery()` -> Laravel `>= 5.5`
+- `Paginator::withQueryString()` -> Laravel `>= 7.0`
+
+## Compatibility matrix
+
+The branch number is the **package version**, not the Laravel version.
+Every package version lives in its own branch and is released from it.
+
+| Package version | Branch   | PHP      | Laravel     | Status                                 |
+| --------------- | -------- | -------- | ----------- | -------------------------------------- |
+| 8.0             | `master` | `>= 7.2` | `>= 5.8`    | Active                                 |
+| 7.0 Beta        | `7.x`    | `>= 7.2` | `>= 7.0`    | Active (Vue views, paginated response) |
+| 6.0             | `6.0`    | `>= 7.2` | `>= 5.8`    | Maintenance                            |
+| 5.9             | `5.9`    | `>= 7.1` | `>= 6.0`    | Maintenance                            |
+| 5.8             | `5.8`    | `>= 7.1` | `>= 7.0`    | Maintenance                            |
+| 5.7             | `5.7`    | `>= 7.1` | `5.8` only  | Legacy                                 |
+| 5.6             | `5.6`    | `>= 7.0` | `>= 5.5`    | Legacy                                 |
+| 5.5             | `5.5`    | `>= 7.0` | `>= 5.5`    | Legacy                                 |
+| 5.4             | `5.4`    | `>= 5.6` | `5.4 - 5.8` | Legacy                                 |
+| 5.3             | `5.3`    | `>= 5.5` | `5.1 - 5.4` | Legacy                                 |
+| 5.0             | `5.0`    | `>= 5.5` | `5.0 - 5.2` | Archived                               |
+
+## Feature matrix
+
+| Version  | BS  | Datatables | Methods | Views engine | Crypt | Constructor | UTC | Validation     |
+| -------- | --- | ---------- | ------- | ------------ | ----- | ----------- | --- | -------------- |
+| 5.5      | 3   | 1.x        | es      | blade        | yes   | yes         | no  | formvalidation |
+| 5.6      | 4   | 1.x        | es      | blade        | yes   | yes         | no  | formvalidation |
+| 5.9      | 4   | 1.x        | es      | blade        | yes   | no          | no  | laravel        |
+| 6.0      | 4   | 1.x        | en      | blade        | yes   | yes         | no  | formvalidation |
+| 7.0 Beta | 4   | 1.x        | en      | vue          | yes   | yes         | no  | formvalidation |
+| 8.0      | 4/5 | 2.x        | en      | blade        | no    | no          | yes | laravel        |
+
+## Installation
+
+```bash
+composer require csgt/crud:^5.3
+```
+
+## Usage
+
+Create a controller that extends `CrudController` and describe the CRUD in
+`__construct()`:
+
+```php
+use Csgt\Crud\CrudController;
+
+class ClientesController extends CrudController
+{
+    public function __construct()
+    {
+        $this->setModelo(new \App\Cliente);
+        $this->setTitulo('Clientes');
+
+        $this->setCampo(['nombre' => 'Nombre', 'campo' => 'nombre']);
+        $this->setCampo(['nombre' => 'Pais', 'campo' => 'pais.nombre', 'isforeign' => true]);
+
+        $this->setPermisos(['add' => true, 'edit' => true, 'delete' => true]);
+    }
+}
+```
+
+Then register the route:
+
+```php
+Route::resource('clientes', 'ClientesController');
+```
+
+## Listing performance
+
+The `data()` endpoint resolves **search, ordering and pagination in the
+database**:
+
+- The DataTables global search becomes a `WHERE ... LIKE` clause, and relation
+  columns are matched through `whereHas`.
+- Ordering by a relation column uses a correlated subquery instead of sorting
+  in memory.
+- Only the requested page is fetched (`offset` + `limit`).
+- `multi` fields are eager loaded, removing the N+1 query per row.
+
+Previously the whole table was loaded into memory and filtered/sorted with
+Collection methods, so the cost grew with the total number of rows instead of
+the page size. No public API changed: `setField`, `setWhere`, `setOrderBy` and
+the JSON response shape are the same.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This package is used to generate cruds.
 
 > **You are on branch `5.3` - package version `5.3`.**
 
+## Documentation for contributors
+
+| Document | Read it for |
+|---|---|
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | How the package is wired: request lifecycle, field metadata, the listing query |
+| [docs/METHODS.md](docs/METHODS.md) | What every method of `CrudController` does on this branch |
+| [docs/RULES.md](docs/RULES.md) | What you may and may not change: no repurposing methods, behaviour changes go to a new version branch, legacy compatibility first |
+
 ## Requirements
 
 | Requirement | Supported |

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,19 @@
       "Csgt\\Crud\\": "src"
     }
   },
-  "minimum-stability" : "stable"
+  "minimum-stability" : "stable",
+  "require-dev": {
+    "phpunit/phpunit": "^9.6 || ^10.5",
+    "illuminate/database": "^8.0 || ^9.0 || ^10.0",
+    "illuminate/routing": "^8.0 || ^9.0 || ^10.0",
+    "illuminate/support": "10.49.0 as 5.1.999"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Csgt\\Crud\\Tests\\": "tests"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
+  }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,208 @@
+# Architecture
+
+Branch `5.3` — package version `5.3`. See `README.md` for the PHP and Laravel
+bounds of this branch, `METHODS.md` for the method reference and `RULES.md` for
+what you are allowed to change.
+
+---
+
+## What the package does
+
+You declare a CRUD by extending `CrudController` and describing an Eloquent
+model plus a list of fields, in Spanish-named methods (`setModelo`, `setCampo`,
+`setTitulo`, ...). From that declaration the package renders the listing, serves
+it to DataTables over AJAX, renders the edit/create form (built with
+`laravelcollective/html` `Form::` helpers), persists the input, and registers
+the routes.
+
+There is no code generation at runtime: one controller subclass plus one route
+line is a full CRUD.
+
+This is the oldest maintained branch. `src/CrudController.php` ends with a
+large `/* ... */` comment block (roughly the last half of the file) containing
+an older, `static`-method version of the class (`getData()`, `setTabla()`,
+`setSlug()`, a second `setCampo()`, ...). It is dead code kept for reference —
+none of it executes, and it is not part of this document. Do not treat any
+method name that only appears inside that comment as part of the API.
+
+## File map
+
+| File | Role |
+|---|---|
+| `src/CrudController.php` | Everything: lifecycle actions, query building, field metadata, setters (plus a large commented-out legacy block at the end) |
+| `src/CrudServiceProvider.php` | Registers views, translations, and swaps the resource registrar. There is no `make:crud` command on this branch (`src/Console/` does not exist). |
+| `src/ResourceRegistrar.php` | Extends Laravel's registrar so `Route::resource` also creates the `data` route |
+| `src/resources/views/index.blade.php` | Listing: DataTables config, column renderers, the global search box |
+| `src/resources/views/edit.blade.php` | Edit/create form, `Form::` helper per field type |
+| `src/resources/lang/{en,es}/crud.php` | All user-facing strings |
+| `src/config/csgtcrud.php` | Package config |
+| `tests/` | PHPUnit suite over the query-building methods |
+
+## Request lifecycle
+
+```
+Route::resource('clientes', ClientesController::class)
+        │
+        │  ResourceRegistrar adds one route to the seven standard ones:
+        │      POST clientes/data          -> data()
+        │  (there is no "detail" route, and no show() action on this branch)
+        ▼
+GET /clientes ─────────► index()
+                          │ builds the column metadata for the view
+                          └─► view csgtcrud::index
+                                  │ DataTables boots with serverSide: true
+                                  ▼
+                        POST /clientes/data ─────► data()
+                                  │ builds ONE query: select, eager loads,
+                                  │ joins, fixed wheres, global search,
+                                  │ order, offset/limit
+                                  └─► JSON { draw, recordsTotal,
+                                             recordsFiltered, data[] }
+
+GET /clientes/create ───► create()  ─────────────► view csgtcrud::edit
+GET /clientes/{id}/edit ► edit($id) ─────────────► view csgtcrud::edit
+POST /clientes ─────────► store()
+PUT  /clientes/{id} ────► update($id)
+DELETE /clientes/{id} ──► destroy($id)
+```
+
+Every action calls the controller's own setup first (`__construct` on this
+branch), so the field declaration is always in place before anything reads it.
+`create()` does not delegate to `edit()`: it is its own method with a
+duplicated body (`$data = null` instead of a model lookup). `store()` does not
+delegate to `update()` either — unlike the newer branches, the two are
+independent methods here. Ids are always decrypted with `Crypt::decrypt()` in
+`edit()`, `update()` and `destroy()` — there is no `show()` action and no
+config flag to disable the decryption on this branch.
+
+`index()` takes no `Request` parameter (`public function index()`), unlike
+every other lifecycle action. There is also no `getQueryString()` helper on
+this branch: `edit()` and `create()` hardcode `'nuevasVars'` to an empty
+string instead of preserving the current query string across a save.
+
+## Field metadata
+
+`setCampo()` is the heart of the package. Each call validates the incoming keys
+against an allow-list and normalises them into one array with a fixed shape,
+appended to `$campos`:
+
+```php
+[
+  'campo'         => 'pais.nombre',       // as declared
+  'nombre'        => 'Pais',              // column header
+  'alias'         => 'pais__nombre',      // safe key for the JSON/DOM
+  'campoReal'     => 'nombre',            // column without the relation
+  'tipo'          => 'string',            // drives rendering
+  'show'          => true,                // appears in the listing
+  'editable'      => true,                // appears in the form
+  'searchable'    => true,                // false for a raw expression
+  ...                                     // default, class, decimales,
+]                                        // filepath, target, ...
+```
+
+There is no `isforeign` key and no `multi` field type on this branch. Only two
+shapes of `campo` exist, and the query code branches on which one it is:
+
+| Shape | Example | Resolved by |
+|---|---|---|
+| local column | `nombre` | `select` on the model's table |
+| relation column | `pais.nombre` (any field containing a `.`) | eager load + correlated subquery for ordering |
+| raw expression | `CONCAT(nombre, id) AS composed` | left as-is in the select (no `DB::raw` wrapping, see `getSelect()` below), `orderByRaw` for ordering, and marked `searchable => false` |
+
+`getCamposShowForeign()` treats **every** field whose `campo` contains a `.`
+as a relation column — there is no `isforeign` flag gating it, and no check for
+a quoted or parenthesised expression either (the `5.4` branch added a `"`
+check; this branch does not have it).
+
+The `getCamposXxx()` helpers are just filters over that list; see `METHODS.md`.
+
+## The listing query
+
+`data()` builds a single query and never materialises more than one page:
+
+```
+$this->modelo->select( local fields + expressions )        getSelect + getCamposShowMine
+   ├── with( relation => fn($q) => addSelect(...) )         getCamposShowForeign
+   ├── addSelect( primary key AS ___id___ )
+   ├── leftJoin(...)                                        setLeftJoin
+   ├── where / whereRaw                                     setWhere, setWhereRaw, fixed filters
+   │
+   ├── recordsTotal = (clone $query)->count()
+   │
+   ├── applySearchToQuery( DataTables global search )       if search.value is not empty
+   ├── recordsFiltered = (clone $query)->count()            only if a search term was applied
+   │
+   ├── applyOrderToQuery( DataTables order )                plain / raw / subquery
+   └── skip(start)->take(length)->get()                     ONE page
+```
+
+Unlike every other branch, `getSelect()` does **not** wrap fields in `DB::raw`
+— it returns the plain strings. There is also no `setWhereIn()` on this branch:
+only `setWhere()` and `setWhereRaw()` exist. `setJoin()` exists as a setter but
+`$this->joins` is never read inside `data()`; it has no observable effect (the
+same is true on every other branch — `leftJoins`, not `joins`, drives the
+query).
+
+The rendering loop then walks `getCamposOrden()` per row and pulls each value:
+the primary key is re-encrypted with `Crypt::encrypt()` and appended as the
+last (unkeyed) element of `$cols` — this branch does not use the `DT_RowId`
+key that later branches use, relation columns are read with `data_get`, and
+everything else is read directly off the row. There is no `securefile`
+temporary-URL handling and no `multi` field on this branch — neither feature
+exists here.
+
+Two invariants hold the performance in place:
+
+1. **Nothing is filtered or sorted in memory.** No `->get()` before the
+   pagination, no Collection `filter`/`sortBy`/`splice`.
+2. **No query inside the row loop.** Anything a row needs is eager loaded before
+   the loop starts.
+
+## Global search
+
+This branch has no per-column filters. The listing keeps the DataTables global
+search box, and `data()` reads `$request->search['value']`. When it is not
+empty, `applySearchToQuery()` builds one `WHERE` group that `orWhereRaw`s
+`LOWER(field) LIKE ?` over every field with `searchable => true`, skipping the
+unique-id column. The alias is stripped first, since `AS alias` is only valid
+in a `SELECT`. `recordsFiltered` is only recounted when a search term was
+actually sent.
+
+There is no `getFilterColumns()` and no `filters[]` payload on this branch —
+those belong to `5.5` and later.
+
+## Ordering
+
+DataTables sends column indices; `getCamposOrden()` maps them back to declared
+fields. Then:
+
+- a plain column → `orderBy`
+- a raw expression → `orderByRaw`, so it is not quoted as an identifier
+- a relation column → a correlated subquery built from
+  `getRelationExistenceQuery()`, **but only when that method exists** on the
+  installed Eloquent (Laravel 5.5+); on an older Eloquent `applyOrderToQuery()`
+  falls back to ordering by the model's primary key instead, since there is no
+  way to build the subquery
+- an unknown relation → falls back to a plain `orderBy`, never throws
+
+This branch's floor is Laravel 5.1 (see `README.md`), which predates
+`getRelationExistenceQuery()` by several major versions, so the
+`method_exists()` guard is load-bearing here, not defensive boilerplate.
+
+## Persistence
+
+`store()` and `update()` are independent, minimal methods on this branch:
+both strip `noGuardar` (always includes `_token`, via the global
+`array_except()` helper) and save. Neither parses dates, moves file uploads,
+merges hidden fields, nor touches `multi` relations — none of that exists yet.
+The `store()` method carries a `//Aqui falta procesar fechas, files, images,
+etc` comment acknowledging the gap. Do not "fix" this by adding that behaviour
+here: per `RULES.md`, a behaviour change belongs on a new version branch, and
+the newer branches (`5.4`+) already have it.
+
+## Extending
+
+The intended extension point is your own subclass: declare fields and filters
+in `__construct`, and override a lifecycle action only when you must, calling
+`parent::` where possible. The private helpers are private on purpose — see
+`RULES.md` before changing any of them.

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -1,0 +1,108 @@
+# Method reference
+
+Branch `5.3` — package version `5.3`. Every active method of
+`Csgt\Crud\CrudController` as it exists on this branch. See `ARCHITECTURE.md`
+for how they fit together and `RULES.md` before changing any of them.
+
+Signatures are copied from the source. **Public methods are contract**: their
+name, signature and observable behaviour cannot change on this branch.
+
+The bottom half of `src/CrudController.php` (roughly lines 613 onward) is a
+`/* ... */` comment containing an older `static`-method version of this class.
+It does not execute and is excluded from this reference — do not treat
+`getData()`, `setTabla()`, `setSlug()`, the `static setCampo()`, or any other
+method that only appears in that comment as part of the API.
+
+---
+
+## Lifecycle actions
+
+Routed by `Route::resource` (the package's `ResourceRegistrar` adds `data` to
+the standard seven).
+
+| Method | Route | Does |
+|---|---|---|
+| `index()` | `GET /resource` | Renders `csgtcrud::index` with the column metadata, permissions, breadcrumb and extra buttons. No query is run here; the rows arrive later over AJAX. Takes no `Request` parameter, unlike every other lifecycle action. |
+| `data(Request $request)` | `POST /resource/data` | Builds the listing query, applies the global search, the order and the page window, and returns the DataTables JSON `{draw, recordsTotal, recordsFiltered, data}`. The hot path of the package. |
+| `edit(Request $request, $aId)` | `GET /resource/{id}/edit` | Renders `csgtcrud::edit` for an existing record (`$aId` decrypted with `Crypt::decrypt()`): editable fields, combo options, breadcrumb. |
+| `create(Request $request)` | `GET /resource/create` | Its own method (does not delegate to `edit()`): renders `csgtcrud::edit` with `$data = null`. |
+| `store(Request $request)` | `POST /resource` | Its own method (does not delegate to `update()`): strips `noGuardar` and creates the record. No date parsing, no file handling, no hidden-field merge. |
+| `update(Request $request, $aId)` | `PUT /resource/{id}` | Strips `noGuardar`, finds the record (`$aId` decrypted) and updates it. Same gap as `store()`. |
+| `destroy(Request $request, $aId)` | `DELETE /resource/{id}` | Deletes the record (`$aId` decrypted), flashes the result message via `Session::flash()` and redirects. |
+
+There is no `show()` action on this branch.
+
+## Listing query helpers
+
+All private. Called from `data()`, and covered by `tests/CrudControllerTest.php`.
+
+| Method | Does | Notes |
+|---|---|---|
+| `applySearchToQuery($query, $searchValue, $columns)` | Builds one `WHERE` group `orWhereRaw`ing `LOWER(field) LIKE ?` over every searchable column. | Skips non-searchable columns and the unique-id column. `$searchValue` is lower-cased and wrapped in `%` inside the method. |
+| `applyOrderToQuery($query, $columnName, $direction)` | Orders in the database: `orderBy` for a plain column, `orderByRaw` for an expression, and a correlated subquery for a relation column. | Falls back to a plain `orderBy` when the relation does not exist on the model. When the relation exists but the installed Eloquent has no `getRelationExistenceQuery()` (pre-5.5 Laravel), falls back to ordering by the model's primary key instead of building the subquery. |
+| `stripAlias($field)` | Returns the expression without its ` as alias` suffix. | `AS` is only valid in a `SELECT`; leaving it in a `WHERE`/`ORDER BY` produces invalid SQL. |
+| `qualifyRelatedColumn($relatedModel, $column)` | Prefixes the related table only when the column is a plain identifier. | Expressions, already-qualified columns and aliases are returned untouched. |
+| `getSelect($aCampos)` | Maps the given fields to their plain `campo` string for the `select`. | Unlike the newer branches, this does **not** wrap the field in `DB::raw()`. |
+
+## Field metadata helpers
+
+Private filters over `$campos`, the list built by `setCampo()`.
+
+| Method | Returns |
+|---|---|
+| `getCamposShow()` | Every field with `show => true`, in declaration order. |
+| `getCamposShowMine()` | Shown fields whose `campo` has no `.` at all. These go into the `select`. |
+| `getCamposShowForeign()` | Shown relation columns grouped by relation name (any field containing a `.`), in the shape `data()` consumes to build the eager loads. |
+| `getCamposEditMine()` | Fields with `editable => true` that are not relation columns; drives the edit form. |
+| `getCamposEdit()` | Every field with `editable => true`. |
+| `getCamposOrden()` | The declared field names in listing order with `___id___` appended; maps a DataTables column index back to a field. |
+
+There is no `getCamposShowMulti()` and no `getFilterColumns()` on this branch:
+`multi` fields and per-column filters do not exist here.
+
+## Rendering helpers
+
+| Method | Visibility | Does |
+|---|---|---|
+| `generarBreadcrumb($aTipo, $aUrl = '')` | private | Builds the breadcrumb HTML for `index`, `edit` or `create`. |
+| `mostrarBreadcrumb($aBool)` | public | Toggles the breadcrumb. |
+| `fillCombos($aCampos)` | private | Resolves the option list of every `combobox` field for the form (`multi` does not exist on this branch). |
+| `downLevel($aPath)` | private | Drops the last segment of a path; used to build the redirect and breadcrumb URLs. |
+
+There is no `getQueryString()`, `getTemplate()` or `getTitulo()` on this
+branch: `edit()` and `create()` hardcode the query string to `''`.
+
+## Setters — the declaration API
+
+Called from your controller's `__construct`. This is the public surface most
+applications depend on; treat every signature as frozen.
+
+| Method | Purpose |
+|---|---|
+| `setModelo($aModelo)` | The Eloquent model the CRUD is built on. Required. |
+| `setCampo($aParams)` | Declares one field. Accepts `campo`, `nombre`, `editable`, `show`, `tipo`, `class`, `default`, `reglas`, `reglasmensaje`, `decimales`, `collection`, `enumarray`, `filepath`, `filewidth`, `fileheight`, `target`. Types (`tipo`): `string`, `numeric`, `date`, `datetime`, `bool`, `combobox`, `password`, `enum`, `file`, `image`, `textarea`, `url`, `summernote`, `securefile`. Rejects unknown keys. No `isforeign` key and no `multi` type on this branch. |
+| `setTitulo($aTitulo)` | Listing title. |
+| `setLayout($aLayout)` | Blade layout to extend. |
+| `setPermisos($aPermisos)` | `add` / `edit` / `delete` flags, assigned directly (no module-callback form). |
+| `setWhere($aColumna, $aOperador, $aValor = null)` | Fixed `WHERE` on the listing. Two-argument form means equality. |
+| `setWhereRaw($aStatement)` | Fixed raw `WHERE`. |
+| `setJoin($aRelation)` / `setLeftJoin($aTabla, $aCol1, $aOperador, $aCol2)` | Extra joins. Only `setLeftJoin`'s result is read by `data()`; `setJoin` has no observable effect. |
+| `setNoGuardar($aCampo)` | Request keys never persisted (`_token` is always ignored). |
+| `setBreadcrumb($aArray)` | Custom breadcrumb trail. |
+| `setBotonExtra($aParams)` | Extra button per row (`url`, `titulo`, `icon`, `class`, `target`, `confirm`, `confirmmessage`). |
+
+There is no `setWhereIn()`, `setOrderBy()`, `setPerPage()`, `setHidden()`,
+`setAccionExtra()` or `setResponsive()` as **active** methods on this branch —
+those names only exist inside the commented-out legacy block. The listing's
+per-column default order and page size (50) are fixed in the class properties
+and cannot be configured from a subclass here.
+
+## Where the tests live
+
+`tests/CrudControllerTest.php` covers the listing query helpers and the field
+metadata helpers by asserting the SQL and the bindings they produce, with the
+private methods reached through the reflection helpers in `tests/TestCase.php`.
+
+Not covered, and why: the lifecycle actions need a booted application (`view()`,
+`config()`, `redirect()`, a real `Request`), which the suite deliberately avoids
+so it can run without a database server or a Laravel app.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,0 +1,148 @@
+# Rules for working on this package
+
+These rules apply to every branch of `csgt/crud`. They exist because this
+package is installed by long-lived applications that pin a branch and rarely
+upgrade: a change that looks harmless here becomes a broken listing in a project
+nobody has touched in three years.
+
+Read `ARCHITECTURE.md` for how the package is wired and `METHODS.md` for what
+each method does before changing anything.
+
+---
+
+## 1. Never repurpose an existing method
+
+A public method that already exists keeps its name, its signature and its
+observable behaviour. Do not:
+
+- change what a method returns or the shape of what it returns
+- add a required parameter, or reorder parameters
+- rename a method, a field key, a config key, a translation key or a view
+  variable
+- change the JSON shape returned by `data()`
+- silently change the meaning of an option (for example making a flag opt-out
+  when it used to be opt-in)
+
+If the new behaviour cannot coexist with the old one, it does not belong in this
+branch. Open it on a new version branch instead — see rule 2.
+
+**Allowed without a new version:** fixing a method that is provably broken (it
+throws, produces invalid SQL, or contradicts its own documented purpose), adding
+a new optional parameter with a default that preserves the current result, and
+adding a brand new method.
+
+## 2. A behaviour change means a new version, not an edit
+
+The branch number is the **package version**, not the Laravel version. Each
+version lives in its own branch and is released from it, so the upgrade path for
+an application is "move to another branch", which is a decision its maintainer
+takes deliberately.
+
+Therefore:
+
+- a breaking change starts a new branch, cut from the newest branch that has the
+  behaviour you want to keep
+- a fix or a backward-compatible addition goes on the branch it belongs to, and
+  is ported to the newer branches that share the same code shape
+- never rewrite history or force-push a released branch
+- the compatibility matrix in `README.md` is part of the change: if you add a
+  branch, or the PHP/Laravel floor of a branch moves, update the matrix in every
+  branch's README
+
+This is the oldest maintained branch: known gaps such as `store()`/`update()`
+not parsing dates or moving file uploads (see `ARCHITECTURE.md`) are exactly
+this kind of behaviour difference. They are already fixed on `5.4` and later.
+Do not port the fix backward onto this branch's public methods — that would be
+a behaviour change without a version bump.
+
+## 3. Legacy compatibility is the priority
+
+When two implementations both work, take the one that keeps working on the
+oldest PHP and Laravel this branch supports. This branch's floor is PHP `>= 5.5`
+and Laravel `5.1` (see `README.md`); before using a framework API, confirm it
+exists in Laravel 5.1. This is the oldest maintained branch in the package, so
+this rule matters more here than almost anywhere else.
+
+Concrete traps that have already bitten this package:
+
+| Do not use on old branches | Because | Use instead |
+|---|---|---|
+| `[$a, $b] = $array` | PHP 7.1+ | `list($a, $b) = $array` or index access |
+| `$query->orderBy($builder, ...)` | Laravel 6+ | `orderByRaw($sub->toSql(), $sub->getBindings())` |
+| `Relation::getRelationExistenceQuery()` | Laravel 5.5+ | guard with `method_exists()` and fall back to ordering by the primary key |
+| `Model::qualifyColumn()` | Laravel 5.5+ | `$model->getTable().'.'.$column` |
+| `Arr::` / `Str::` | Laravel 5.5+ | the global helpers (`array_except()`, ...) on this branch |
+| Package auto-discovery (`extra.laravel.providers`) | Laravel 5.5+ | register the service provider manually in `config/app.php` |
+| `$request->session()` | not reliably available pre-5.3 sessions | the `Session` facade, as this branch's `destroy()` already does |
+| `BelongsTo::getOwnerKeyName()` | Laravel 5.8+ | avoid entirely on this branch |
+
+`applyOrderToQuery()` already applies the `getRelationExistenceQuery()` guard:
+it only builds the correlated subquery when
+`method_exists($relation, 'getRelationExistenceQuery')` is true, and falls back
+to ordering by the model's primary key otherwise, since this branch's floor
+(Laravel 5.1) is several major versions older than that method. Do not remove
+the guard.
+
+Never widen or tighten the `require` block of `composer.json` to make your
+change fit. Dev-only tooling belongs in `require-dev`, where it cannot affect an
+application that installs the package.
+
+## 4. Every change to the query pipeline needs a test
+
+The listing query is the part of this package that silently breaks. Anything
+touching `data()` or its helpers ships with a test in `tests/` asserting the
+generated SQL and bindings.
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+This branch's runtime `require` pins `illuminate/support: ~5.1`, which the
+modern Eloquent the test suite runs against cannot satisfy. `require-dev`
+therefore declares `"illuminate/support": "10.49.0 as 5.1.999"`: Composer
+installs the modern package for the dev environment while still satisfying the
+old root constraint. This is a dev-only alias — it does not change what an
+application installing the package with `composer install --no-dev` receives.
+Do not remove it to "simplify" `composer.json`, and do not let it leak into the
+`require` block.
+
+The suite must run without a database server: assert on `toSql()` and
+`getBindings()`, never execute the query. If a test fails, first check whether
+the source really behaves differently on this branch — adjust the source or the
+expectation deliberately, never weaken an assertion to get to green.
+
+Filtering, ordering and pagination happen **in the database**. Do not reintroduce
+`->get()` followed by Collection `filter`/`sortBy`/`splice`: that loads the whole
+table into memory and the cost grows with the table instead of the page.
+
+## 5. User-facing text goes through the translation files
+
+No hardcoded Spanish or English in views or controllers. Add the key to both
+`src/resources/lang/en/crud.php` and `src/resources/lang/es/crud.php`, and reach
+it with `trans('csgtcrud::crud.key')`.
+
+## 6. Conventions
+
+- Match the file you are editing: indentation, brace style and alignment differ
+  between branches, and a reformatting diff hides the real change. This branch
+  uses tabs and a compact brace style (`function foo(){` on one line); do not
+  reformat it to match a newer branch's spacing.
+- Commit messages and PR titles/bodies in English, in the imperative mood, with
+  a body explaining *why* when it is not obvious.
+- One concern per commit. A port, a test and a doc update are three commits.
+- Do not commit `composer.lock` or `vendor/`; both are ignored.
+- Do not "clean up" the commented-out legacy block at the end of
+  `CrudController.php` as part of an unrelated change; if it is ever removed,
+  that is its own reviewed commit.
+
+## 7. Checklist before opening a PR
+
+- [ ] No existing method changed name, signature or observable behaviour (rule 1)
+- [ ] If behaviour had to change, it is on a new version branch (rule 2)
+- [ ] No API newer than this branch's supported Laravel/PHP floor (rule 3)
+- [ ] `vendor/bin/phpunit` is green, and the change is covered (rule 4)
+- [ ] New strings exist in both language files (rule 5)
+- [ ] `composer.json` `require` untouched
+- [ ] The change is ported to the other branches that share the same code shape,
+      or the PR says explicitly why it is not

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/CrudController.php
+++ b/src/CrudController.php
@@ -2,7 +2,7 @@
 namespace Csgt\Crud;
 
 use Illuminate\Routing\Controller as BaseController;;
-use Response,Crypt, Session;
+use Response,Crypt, Session, DB;
 use Illuminate\Http\Request;
 
 class CrudController extends BaseController {
@@ -397,7 +397,7 @@ class CrudController extends BaseController {
 			$relatedModel->newQuery(),
 			$query
 		)
-			->select(\DB::raw($this->qualifyRelatedColumn($relatedModel, $relatedColumn)))
+			->select(DB::raw($this->qualifyRelatedColumn($relatedModel, $relatedColumn)))
 			->limit(1);
 
 		$query->orderByRaw('(' . $relationQuery->toSql() . ') ' . $direction, $relationQuery->getBindings());

--- a/src/CrudController.php
+++ b/src/CrudController.php
@@ -284,29 +284,38 @@ class CrudController extends BaseController {
 			$data->whereRaw($whereRaw);
 		}
 		//Obtenemos la cantidad de registros antes de filtrar
-		$recordsTotal = $data->count();
-		//Filtramos con el campo de la vista
-		$data->where(function($q) use ($columns, $search){
-			if ($columns) {
-				foreach ($columns as $column) {
-					if($column['searchable']){
-						//$select = explode(' AS ', $selects[$i]);
-						$q->orWhere($column['campo'], 'like', '%'.$search['value'].'%');
-					}
-				}
-			}
-		});
+		$recordsTotal = (clone $data)->count();
+		//Filtramos con el campo de la vista, directamente en la base de datos
+		if($search['value'] <> ''){
+			$this->applySearchToQuery($data, $search['value'], $columns);
+		}
 
 		//Obtenemos la cantidad de registros luego de haber filtrado
-		$recordsFiltered = $data->count();
-		//Filtramos los registros y obtenemos el arreglo con la data
+		$recordsFiltered = $search['value'] <> '' ? (clone $data)->count() : $recordsTotal;
+
+		$ordenColumnas = $this->getCamposOrden();
+		//Ahora order by, tambien en la base de datos
+		if($request->order){
+			foreach($request->order as $order){
+				$columnName = isset($ordenColumnas[$order['column']]) ? $ordenColumnas[$order['column']] : null;
+				if($columnName === null) continue;
+
+				$direction = strtolower($order['dir']) == 'desc' ? 'desc' : 'asc';
+
+				if($columnName == $this->uniqueid)
+					$data->orderBy($this->modelo->getTable() . '.' . $this->modelo->getKeyName(), $direction);
+				else
+					$this->applyOrderToQuery($data, $columnName, $direction);
+			}
+		}
+
+		//Paginamos en la base de datos y obtenemos unicamente la pagina solicitada
 		$items = $data
 			->skip($request->start)
 			->take($request->length)
-			->get()->toArray();
+			->get();
 
 		$arr = [];
-		$ordenColumnas = $this->getCamposOrden();
 		foreach($items as $item) {
 			$cols = [];
 			$lastItem = '';
@@ -327,10 +336,14 @@ class CrudController extends BaseController {
 				if ($colName == $this->uniqueid) $lastItem = Crypt::encrypt($item[$colName]);
 				else if($esRelacion){
 					//Se chequea si el restultado de la relaci'on es de uno a uno o de uno a muchos
-					if(array_key_exists(0, $item[$relationName]))
-						$cols[] = $item[$relationName][0][$colName];
-					else
-						$cols[] = $item[$relationName][$colName];
+					$relation = $item[$relationName];
+
+					if($relation instanceof \Illuminate\Support\Collection)
+						$relation = $relation->first();
+					else if(is_array($relation) && array_key_exists(0, $relation))
+						$relation = $relation[0];
+
+					$cols[] = data_get($relation, $colName);
 				}
 				else $cols[] = $item[$colName];
 			}
@@ -339,6 +352,98 @@ class CrudController extends BaseController {
 			$arr[] = $cols;
 		}
 		return response()->json(['draw' => $request->draw, 'recordsTotal' => $recordsTotal, 'recordsFiltered' => $recordsFiltered, 'data' => $arr]);
+	}
+
+	/**
+	 * Ordena en la base de datos. Si la columna pertenece a una relacion se ordena
+	 * con un subquery correlacionado, cuando la version de Laravel lo permite.
+	 */
+	private function applyOrderToQuery($query, $columnName, $direction){
+		$columnName = $this->stripAlias($columnName);
+		$isRelation = strpos($columnName, '.') !== false && strpos($columnName, '"') === false
+			&& strpos($columnName, '(') === false;
+
+		if(!$isRelation){
+			if(strpos($columnName, '(') !== false || strpos($columnName, ' ') !== false)
+				$query->orderByRaw($columnName . ' ' . $direction);
+			else
+				$query->orderBy($columnName, $direction);
+
+			return;
+		}
+
+		$partes        = explode('.', $columnName, 2);
+		$relationName  = $partes[0];
+		$relatedColumn = $partes[1];
+
+		if(!method_exists($this->modelo, $relationName)){
+			$query->orderBy($columnName, $direction);
+
+			return;
+		}
+
+		$relation = $this->modelo->{$relationName}();
+
+		//getRelationExistenceQuery existe a partir de Laravel 5.5. En versiones
+		//anteriores se ordena por la llave primaria para no romper la consulta.
+		if(!method_exists($relation, 'getRelationExistenceQuery')){
+			$query->orderBy($this->modelo->getTable() . '.' . $this->modelo->getKeyName(), $direction);
+
+			return;
+		}
+
+		$relatedModel  = $relation->getRelated();
+		$relationQuery = $relation->getRelationExistenceQuery(
+			$relatedModel->newQuery(),
+			$query
+		)
+			->select(\DB::raw($this->qualifyRelatedColumn($relatedModel, $relatedColumn)))
+			->limit(1);
+
+		$query->orderByRaw('(' . $relationQuery->toSql() . ') ' . $direction, $relationQuery->getBindings());
+	}
+
+	/**
+	 * Devuelve la expresion sin el alias, para poder usarla dentro de un WHERE.
+	 */
+	private function stripAlias($field){
+		$field = trim($field);
+		$pos   = stripos($field, ' as ');
+
+		if($pos !== false) $field = trim(substr($field, 0, $pos));
+
+		return $field;
+	}
+
+	/**
+	 * Antepone la tabla a la columna solo cuando es un identificador simple.
+	 */
+	private function qualifyRelatedColumn($relatedModel, $column){
+		$column = trim($column);
+
+		if(strpos($column, '(') !== false || strpos($column, ' ') !== false || strpos($column, '.') !== false)
+			return $column;
+
+		return $relatedModel->getTable() . '.' . $column;
+	}
+
+	/**
+	 * Aplica la busqueda global de DataTables como un WHERE en la base de datos,
+	 * sobre las mismas columnas marcadas como searchable.
+	 */
+	private function applySearchToQuery($query, $searchValue, $columns){
+		$searchValue = '%' . mb_strtolower(trim($searchValue)) . '%';
+
+		$query->where(function($q) use ($searchValue, $columns){
+			foreach($columns as $column){
+				if(!$column['searchable']) continue;
+
+				$field = $this->stripAlias($column['campo']);
+				if($field == '' || $field == $this->uniqueid) continue;
+
+				$q->orWhereRaw('LOWER(' . $field . ') LIKE ?', [$searchValue]);
+			}
+		});
 	}
 
 	public function setModelo($aModelo){

--- a/tests/CrudControllerTest.php
+++ b/tests/CrudControllerTest.php
@@ -97,16 +97,19 @@ class CrudControllerTest extends TestCase {
 		$this->assertStringContainsString('order by CONCAT(name, id) asc', $query->toSql());
 	}
 
-	// No hay prueba para el ordenamiento por relacion via subquery correlacionado:
-	// esa rama llama \DB::raw() y el archivo no tiene "use DB;" (bug preexistente,
-	// no se corrige aqui). Solo funciona si algo externo registra el alias global
-	// "DB" (una app Laravel real lo hace); no queremos que la suite dependa de eso.
-	// El resto de applyOrderToQuery (columna local, expresion cruda y el fallback
-	// de relacion desconocida) no toca esa linea y si esta cubierto arriba/abajo.
-	// Nota: cuando el Eloquent instalado no tiene getRelationExistenceQuery
-	// (Laravel < 5.5) esta rama tampoco se alcanza y cae al orden por la llave
-	// primaria; con nuestra dependencia de desarrollo (Eloquent moderno) si se
-	// alcanzaria de tener una prueba.
+	public function testApplyOrderToQueryOrdersARelationWithACorrelatedSubquery() {
+		// Cuando el Eloquent instalado expone getRelationExistenceQuery (Laravel 5.5
+		// en adelante) se ordena con un subquery correlacionado. En versiones
+		// anteriores esta rama no se alcanza y se ordena por la llave primaria.
+		$query = $this->query();
+		$this->call($this->controller, 'applyOrderToQuery', [$query, 'country.name', 'desc']);
+
+		$sql = $query->toSql();
+
+		$this->assertStringContainsString('order by (select countries.name from "countries"', $sql);
+		$this->assertStringContainsString('"clients"."country_id" = "countries"."id"', $sql);
+		$this->assertStringContainsString('limit 1) desc', $sql);
+	}
 
 	public function testApplyOrderToQueryFallsBackToAPlainOrderForAnUnknownRelation() {
 		$query = $this->query();

--- a/tests/CrudControllerTest.php
+++ b/tests/CrudControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+namespace Csgt\Crud\Tests;
+
+use Csgt\Crud\Tests\Fixtures\Client;
+use Csgt\Crud\Tests\Fixtures\ClientsController;
+
+/**
+ * Un grupo de pruebas por cada metodo de CrudController que arma la consulta de
+ * listado. Todo se comprueba sobre el SQL y los bindings generados.
+ *
+ * Esta rama no tiene ningun flag "isforeign" en los campos: una columna de
+ * relacion se detecta unicamente por el punto en "campo" (ver
+ * getCamposShowForeign / applyOrderToQuery). Tampoco hay filtro por columna:
+ * el listado solo soporta la busqueda global de DataTables via applySearchToQuery.
+ */
+class CrudControllerTest extends TestCase {
+	protected $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new ClientsController;
+	}
+
+	protected function query() {
+		return Client::query();
+	}
+
+	/*==================== getSelect ====================*/
+
+	public function testGetSelectReturnsOneExpressionPerLocalShownField() {
+		$columns = $this->call($this->controller, 'getCamposShowMine');
+		$select  = $this->call($this->controller, 'getSelect', [$columns]);
+
+		$this->assertSame(['name', 'email', 'CONCAT(name, id)'], $select);
+	}
+
+	/*==================== getCamposShowMine ====================*/
+
+	public function testGetCamposShowMineExcludesRelationsAndHiddenFields() {
+		$fields = array_column($this->call($this->controller, 'getCamposShowMine'), 'campo');
+
+		$this->assertSame(['name', 'email', 'CONCAT(name, id)'], $fields);
+	}
+
+	/*==================== getCamposShowForeign ====================*/
+
+	public function testGetCamposShowForeignGroupsColumnsByRelation() {
+		$foreigns = $this->call($this->controller, 'getCamposShowForeign');
+
+		$this->assertSame(['country'], array_keys($foreigns));
+		$this->assertSame('name', $foreigns['country'][0][0]);
+	}
+
+	/*==================== getCamposOrden ====================*/
+
+	public function testGetCamposOrdenKeepsColumnOrderAndAppendsTheUniqueId() {
+		$order = $this->call($this->controller, 'getCamposOrden');
+
+		$this->assertSame(
+			['name', 'country.name', 'email', 'CONCAT(name, id)', '___id___'],
+			$order
+		);
+	}
+
+	/*==================== stripAlias ====================*/
+
+	public function testStripAliasRemovesTheAliasAndKeepsPlainColumns() {
+		$this->assertSame('country.name', $this->call($this->controller, 'stripAlias', ['country.name AS country_name']));
+		$this->assertSame('name', $this->call($this->controller, 'stripAlias', ['  name  ']));
+		$this->assertSame('CONCAT(a, b)', $this->call($this->controller, 'stripAlias', ['CONCAT(a, b) as composed']));
+	}
+
+	/*==================== qualifyRelatedColumn ====================*/
+
+	public function testQualifyRelatedColumnOnlyPrefixesPlainIdentifiers() {
+		$model = new \Csgt\Crud\Tests\Fixtures\Country;
+
+		$this->assertSame('countries.name', $this->call($this->controller, 'qualifyRelatedColumn', [$model, 'name']));
+		$this->assertSame('CONCAT(a, b)', $this->call($this->controller, 'qualifyRelatedColumn', [$model, 'CONCAT(a, b)']));
+		$this->assertSame('other.name', $this->call($this->controller, 'qualifyRelatedColumn', [$model, 'other.name']));
+	}
+
+	/*==================== applyOrderToQuery ====================*/
+
+	public function testApplyOrderToQueryOrdersALocalColumn() {
+		$query = $this->query();
+		$this->call($this->controller, 'applyOrderToQuery', [$query, 'name', 'desc']);
+
+		$this->assertStringContainsString('order by "name" desc', $query->toSql());
+	}
+
+	public function testApplyOrderToQueryOrdersARawExpressionWithoutQuotingIt() {
+		$query = $this->query();
+		$this->call($this->controller, 'applyOrderToQuery', [$query, 'CONCAT(name, id)', 'asc']);
+
+		$this->assertStringContainsString('order by CONCAT(name, id) asc', $query->toSql());
+	}
+
+	// No hay prueba para el ordenamiento por relacion via subquery correlacionado:
+	// esa rama llama \DB::raw() y el archivo no tiene "use DB;" (bug preexistente,
+	// no se corrige aqui). Solo funciona si algo externo registra el alias global
+	// "DB" (una app Laravel real lo hace); no queremos que la suite dependa de eso.
+	// El resto de applyOrderToQuery (columna local, expresion cruda y el fallback
+	// de relacion desconocida) no toca esa linea y si esta cubierto arriba/abajo.
+	// Nota: cuando el Eloquent instalado no tiene getRelationExistenceQuery
+	// (Laravel < 5.5) esta rama tampoco se alcanza y cae al orden por la llave
+	// primaria; con nuestra dependencia de desarrollo (Eloquent moderno) si se
+	// alcanzaria de tener una prueba.
+
+	public function testApplyOrderToQueryFallsBackToAPlainOrderForAnUnknownRelation() {
+		$query = $this->query();
+		$this->call($this->controller, 'applyOrderToQuery', [$query, 'missing.name', 'asc']);
+
+		$this->assertStringContainsString('order by "missing"."name" asc', $query->toSql());
+	}
+
+	/*==================== applySearchToQuery ====================*/
+
+	public function testApplySearchToQueryFiltersOverTheGivenSearchableColumns() {
+		// This is exactly what data() passes: the local shown columns. CONCAT(name, id)
+		// is not searchable (see below), so only the two plain columns take part.
+		$columns = $this->call($this->controller, 'getCamposShowMine');
+		$query   = $this->query();
+
+		$this->call($this->controller, 'applySearchToQuery', [$query, 'ACME', $columns]);
+
+		$sql = $query->toSql();
+
+		$this->assertStringContainsString('LOWER(name) LIKE ?', $sql);
+		$this->assertStringContainsString('LOWER(email) LIKE ?', $sql);
+		$this->assertStringNotContainsString('CONCAT', $sql);
+		$this->assertSame(['%acme%', '%acme%'], $query->getBindings());
+	}
+
+	public function testApplySearchToQuerySkipsColumnsThatAreNotSearchable() {
+		// setCampo marca automaticamente searchable=false para expresiones con
+		// parentesis (ver 'CONCAT(name, id)'), asi que este campo se filtra solo.
+		$columns = $this->call($this->controller, 'getCamposShow');
+		$query   = $this->query();
+
+		$this->call($this->controller, 'applySearchToQuery', [$query, 'acme', $columns]);
+
+		$sql = $query->toSql();
+
+		$this->assertStringContainsString('LOWER(name) LIKE ?', $sql);
+		$this->assertStringContainsString('LOWER(country.name) LIKE ?', $sql);
+		$this->assertStringContainsString('LOWER(email) LIKE ?', $sql);
+		$this->assertStringNotContainsString('CONCAT', $sql);
+		$this->assertSame(['%acme%', '%acme%', '%acme%'], $query->getBindings());
+	}
+
+	public function testApplySearchToQuerySkipsTheUniqueIdColumn() {
+		$columns = [
+			['campo' => '___id___', 'searchable' => true],
+		];
+		$query = $this->query();
+
+		$this->call($this->controller, 'applySearchToQuery', [$query, 'acme', $columns]);
+
+		$this->assertSame([], $query->getBindings());
+	}
+
+	/*==================== downLevel ====================*/
+
+	public function testDownLevelRemovesTheLastSegmentOfThePath() {
+		$this->assertSame('clients', $this->call($this->controller, 'downLevel', ['clients/5']));
+		$this->assertSame('', $this->call($this->controller, 'downLevel', ['clients']));
+	}
+
+	/*==================== setters ====================*/
+
+	public function testSetCampoAndSetTituloStoreFields() {
+		$this->assertSame('Clients', $this->read($this->controller, 'titulo'));
+		$this->assertCount(5, $this->read($this->controller, 'campos'));
+	}
+
+	public function testSetCampoMarksExpressionFieldsAsNotSearchable() {
+		$campos = $this->read($this->controller, 'campos');
+
+		$this->assertTrue($campos[0]['searchable']);
+		$this->assertFalse($campos[3]['searchable']);
+	}
+}

--- a/tests/Fixtures/Client.php
+++ b/tests/Fixtures/Client.php
@@ -1,0 +1,14 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model {
+	public $timestamps = false;
+
+	protected $table = 'clients';
+
+	public function country() {
+		return $this->belongsTo(Country::class, 'country_id');
+	}
+}

--- a/tests/Fixtures/ClientsController.php
+++ b/tests/Fixtures/ClientsController.php
@@ -1,0 +1,21 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Csgt\Crud\CrudController;
+
+/**
+ * Controller minimo usado por las pruebas: declara los mismos campos que un CRUD
+ * real declararia, sin tocar el framework mas alla de Eloquent.
+ */
+class ClientsController extends CrudController {
+	public function __construct() {
+		$this->setModelo(new Client);
+		$this->setTitulo('Clients');
+
+		$this->setCampo(['campo' => 'name', 'nombre' => 'Name']);
+		$this->setCampo(['campo' => 'country.name', 'nombre' => 'Country']);
+		$this->setCampo(['campo' => 'email', 'nombre' => 'Email']);
+		$this->setCampo(['campo' => 'CONCAT(name, id)', 'nombre' => 'Composed']);
+		$this->setCampo(['campo' => 'secret', 'nombre' => 'Secret', 'show' => false]);
+	}
+}

--- a/tests/Fixtures/Country.php
+++ b/tests/Fixtures/Country.php
@@ -1,0 +1,10 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Country extends Model {
+	public $timestamps = false;
+
+	protected $table = 'countries';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,71 @@
+<?php
+namespace Csgt\Crud\Tests;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use ReflectionMethod;
+
+/**
+ * Base for the package tests.
+ *
+ * The suite asserts on the SQL and the bindings each method builds, so it needs
+ * Eloquent and a connection, but never a live database server: no query is ever
+ * executed. That keeps the suite runnable anywhere PHP and composer are.
+ */
+abstract class TestCase extends BaseTestCase {
+	protected static $capsule;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if (static::$capsule) return;
+
+		//El codigo del paquete usa los alias globales que registra una app Laravel.
+		foreach (['DB' => 'Illuminate\\Support\\Facades\\DB', 'Storage' => 'Illuminate\\Support\\Facades\\Storage'] as $alias => $facade) {
+			if (!class_exists($alias, false)) class_alias($facade, $alias);
+		}
+
+		$container = new Container;
+
+		static::$capsule = new Capsule($container);
+		static::$capsule->addConnection([
+			'driver'   => 'sqlite',
+			'database' => ':memory:',
+			'prefix'   => '',
+		]);
+		static::$capsule->setAsGlobal();
+		static::$capsule->bootEloquent();
+
+		$container->instance('db', static::$capsule->getDatabaseManager());
+		Container::setInstance($container);
+		Facade::setFacadeApplication($container);
+	}
+
+	/**
+	 * Llama un metodo privado o protegido del controller bajo prueba.
+	 */
+	protected function call($object, $method, array $arguments = []) {
+		$reflection = new ReflectionMethod($object, $method);
+		$reflection->setAccessible(true);
+
+		return $reflection->invokeArgs($object, $arguments);
+	}
+
+	/**
+	 * Lee una propiedad privada o protegida del controller bajo prueba.
+	 */
+	protected function read($object, $property) {
+		$class = new \ReflectionClass($object);
+
+		while (!$class->hasProperty($property) && $class->getParentClass()) {
+			$class = $class->getParentClass();
+		}
+
+		$reflection = $class->getProperty($property);
+		$reflection->setAccessible(true);
+
+		return $reflection->getValue($object);
+	}
+}


### PR DESCRIPTION
## What

1. **Listing query** — search, ordering and pagination now run in the database.
2. **Tests** — adds a PHPUnit suite covering the methods that build that query.
3. **README** — documents the PHP and Laravel versions this branch supports.

## How

- The global search becomes a `LOWER(col) LIKE ?` clause over the columns
  flagged as `searchable`, and it only runs when there is a search term.
- Record counts are taken from cloned builders, so `recordsFiltered` is correct.
- Ordering runs as `ORDER BY`. A relation column uses a correlated subquery when
  the installed Eloquent exposes `getRelationExistenceQuery()` (Laravel 5.5 and
  up) and falls back to the primary key otherwise, so nothing breaks on the old
  Laravel versions this branch targets.
- Aliased expressions (`col AS alias`) are stripped before being used inside
  `WHERE`/`ORDER BY`, and raw expressions are ordered with `orderByRaw` so they
  are not quoted as identifiers.

## Not included: the per-column filters

`feat: search by column, multifilter` was **not** ported here. It relies on the
`isforeign` and `tipo` metadata that `setCampo` does not accept on this branch,
so it cannot work without changing the field API. Use branch `5.5` or newer for
that feature.

## One bug fixed

The file lives in the `Csgt\Crud` namespace but referenced `DB::` unqualified
(`DB::table`, `DB::raw`, `DB::select`), which PHP resolves to `Csgt\Crud\DB`.
Those calls were a fatal error waiting for the code path to be reached. `use DB;`
is now imported, so every reference resolves to the facade alias the application
registers, and the correlated-subquery ordering path is covered by a test.

## Compatibility

The public API and the JSON response shape are unchanged, and the runtime
`composer.json` constraints were not touched. No API newer than this branch's
Laravel target was introduced in `src/`.

## Testing

`composer install && vendor/bin/phpunit`.

The suite asserts on the SQL and the bindings each method produces and never
touches a database server. The test tooling is `require-dev` only; see the
README for the note about the `illuminate/support` dev alias this branch needs.

A manual pass over one listing per project is still recommended before tagging
a release, since the suite does not assert against live rows.

