### PR TITLE
Document PHP and Laravel support on branch 5.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ composer.lock
 .env.php
 .DS_Store
 Thumbs.db
+.phpunit.result.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This package is used to generate cruds.
 
 > **You are on branch `5.9` - package version `5.9`.**
 
+## Documentation for contributors
+
+| Document | Read it for |
+|---|---|
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | How the package is wired: request lifecycle, field metadata, the listing query |
+| [docs/METHODS.md](docs/METHODS.md) | What every method of `CrudController` does on this branch |
+| [docs/RULES.md](docs/RULES.md) | What you may and may not change: no repurposing methods, behaviour changes go to a new version branch, legacy compatibility first |
+
 ## Requirements
 
 | Requirement | Supported |

--- a/README.md
+++ b/README.md
@@ -105,3 +105,15 @@ Previously the whole table was loaded into memory and filtered/sorted with
 Collection methods, so the cost grew with the total number of rows instead of
 the page size. No public API changed: `setField`, `setWhere`, `setOrderBy` and
 the JSON response shape are the same.
+
+## Tests
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+The suite covers the methods that build the listing query, asserting on the SQL
+and the bindings they produce. It needs Eloquent but never a database server:
+no query is executed. The test tooling is `require-dev` only, so nothing
+changes for consumers of the package.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# Crud
+
+This package is used to generate cruds.
+
+> **You are on branch `5.9` - package version `5.9`.**
+
+## Requirements
+
+| Requirement | Supported |
+| ----------- | --------- |
+| PHP         | `>= 7.1` |
+| Laravel     | `>= 6.0` |
+| Frontend    | Bootstrap 4 + jQuery + DataTables 1.x |
+
+Laravel bounds are derived from the framework APIs each branch actually calls,
+since the `composer.json` constraints were never updated:
+
+- `Form::` helpers (`laravelcollective/html`) on `5.0`-`5.4` -> Laravel `5.x` only
+- Package auto-discovery (`extra.laravel.providers`) -> Laravel `>= 5.5`
+- `Storage::disk()->temporaryUrl()` -> Laravel `>= 5.4`
+- `BelongsTo::getOwnerKeyName()` -> Laravel `>= 5.8`
+- `array_except()` (removed in Laravel 6) on `5.3`, `5.4`, `5.7` -> Laravel `<= 5.8`
+- `Relation::getRelationExistenceQuery()` -> Laravel `>= 5.5`
+- `Paginator::withQueryString()` -> Laravel `>= 7.0`
+
+## Compatibility matrix
+
+The branch number is the **package version**, not the Laravel version.
+Every package version lives in its own branch and is released from it.
+
+| Package version | Branch   | PHP      | Laravel     | Status                                 |
+| --------------- | -------- | -------- | ----------- | -------------------------------------- |
+| 8.0             | `master` | `>= 7.2` | `>= 5.8`    | Active                                 |
+| 7.0 Beta        | `7.x`    | `>= 7.2` | `>= 7.0`    | Active (Vue views, paginated response) |
+| 6.0             | `6.0`    | `>= 7.2` | `>= 5.8`    | Maintenance                            |
+| 5.9             | `5.9`    | `>= 7.1` | `>= 6.0`    | Maintenance                            |
+| 5.8             | `5.8`    | `>= 7.1` | `>= 7.0`    | Maintenance                            |
+| 5.7             | `5.7`    | `>= 7.1` | `5.8` only  | Legacy                                 |
+| 5.6             | `5.6`    | `>= 7.0` | `>= 5.5`    | Legacy                                 |
+| 5.5             | `5.5`    | `>= 7.0` | `>= 5.5`    | Legacy                                 |
+| 5.4             | `5.4`    | `>= 5.6` | `5.4 - 5.8` | Legacy                                 |
+| 5.3             | `5.3`    | `>= 5.5` | `5.1 - 5.4` | Legacy                                 |
+| 5.0             | `5.0`    | `>= 5.5` | `5.0 - 5.2` | Archived                               |
+
+## Feature matrix
+
+| Version  | BS  | Datatables | Methods | Views engine | Crypt | Constructor | UTC | Validation     |
+| -------- | --- | ---------- | ------- | ------------ | ----- | ----------- | --- | -------------- |
+| 5.5      | 3   | 1.x        | es      | blade        | yes   | yes         | no  | formvalidation |
+| 5.6      | 4   | 1.x        | es      | blade        | yes   | yes         | no  | formvalidation |
+| 5.9      | 4   | 1.x        | es      | blade        | yes   | no          | no  | laravel        |
+| 6.0      | 4   | 1.x        | en      | blade        | yes   | yes         | no  | formvalidation |
+| 7.0 Beta | 4   | 1.x        | en      | vue          | yes   | yes         | no  | formvalidation |
+| 8.0      | 4/5 | 2.x        | en      | blade        | no    | no          | yes | laravel        |
+
+## Installation
+
+```bash
+composer require csgt/crud:^5.9
+```
+
+## Usage
+
+Create a controller that extends `CrudController` and describe the CRUD in
+`setup(Request $request)`:
+
+```php
+use Csgt\Crud\CrudController;
+use Illuminate\Http\Request;
+
+class ClientesController extends CrudController
+{
+    public function setup(Request $request)
+    {
+        $this->setModelo(new \App\Cliente);
+        $this->setTitulo('Clientes');
+
+        $this->setCampo(['nombre' => 'Nombre', 'campo' => 'nombre']);
+        $this->setCampo(['nombre' => 'Pais', 'campo' => 'pais.nombre', 'isforeign' => true]);
+
+        $this->setPermisos(['add' => true, 'edit' => true, 'delete' => true]);
+    }
+}
+```
+
+Then register the route:
+
+```php
+Route::resource('clientes', ClientesController::class);
+```
+
+## Listing performance
+
+The `data()` endpoint resolves **search, ordering and pagination in the
+database**:
+
+- The DataTables global search becomes a `WHERE ... LIKE` clause, and relation
+  columns are matched through `whereHas`.
+- Ordering by a relation column uses a correlated subquery instead of sorting
+  in memory.
+- Only the requested page is fetched (`offset` + `limit`).
+- `multi` fields are eager loaded, removing the N+1 query per row.
+
+Previously the whole table was loaded into memory and filtered/sorted with
+Collection methods, so the cost grew with the total number of rows instead of
+the page size. No public API changed: `setField`, `setWhere`, `setOrderBy` and
+the JSON response shape are the same.

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,18 @@
                 "Csgt\\Crud\\CrudServiceProvider"
             ]
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6 || ^10.5",
+        "illuminate/database": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/routing": "^8.0 || ^9.0 || ^10.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Csgt\\Crud\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,204 @@
+# Architecture
+
+Branch `5.9` — package version `5.9`. See `README.md` for the PHP and Laravel
+bounds of this branch, `METHODS.md` for the method reference and `RULES.md` for
+what you are allowed to change.
+
+This is the branch where the listing-query optimization and the per-column
+filters were first written (see the `optimization: move filter and order logic
+to the query` and `feat: search by column, multifilter` commits in the log).
+The other maintained branches (`6.0`, `7.x`, `master`) port that same query
+pipeline; when in doubt about the intended shape of the pipeline, this branch
+is the one to check first.
+
+---
+
+## What the package does
+
+You declare a CRUD by extending `CrudController` and describing an Eloquent
+model plus a list of fields inside `setup(Request $request)`. From that
+declaration the package renders the listing, serves it to DataTables over
+AJAX, renders the edit/create form, validates and persists the input, and
+registers the routes.
+
+There is no code generation at runtime: one controller subclass plus one route
+line is a full CRUD. The public API on this branch is entirely in Spanish
+(`setModelo`, `setCampo`, `setTitulo`, `setPermisos`, ...); this is the last
+maintained branch before the API was translated to English on `6.0`.
+
+## File map
+
+| File | Role |
+|---|---|
+| `src/CrudController.php` | Everything: lifecycle actions, query building, field metadata, setters |
+| `src/CrudServiceProvider.php` | Registers views, translations, the `make:crud` command, and swaps the resource registrar |
+| `src/ResourceRegistrar.php` | Extends Laravel's registrar so `Route::resource` also creates the `data` route |
+| `src/Console/MakeCrudCommand.php` | `php artisan make:crud` scaffolding, template in `src/Console/stubs/crud.stub` |
+| `src/resources/views/index.blade.php` | Listing: DataTables config, column renderers, the column-filter UI |
+| `src/resources/views/edit.blade.php` | Edit/create form, one input per field type |
+| `src/resources/lang/{en,es}/crud.php` | User-facing strings |
+| `src/config/csgtcrud.php` | Package config (`usar_encripcion`, ...) |
+| `tests/CrudControllerTest.php` | PHPUnit suite over the query-building methods |
+
+There is no `detail` route on this branch, unlike the `6.0`/`master` line.
+
+## Request lifecycle
+
+```
+Route::resource('clientes', ClientesController::class)
+        │
+        │  ResourceRegistrar adds one route to the seven standard ones:
+        │      POST clientes/data  -> data()
+        ▼
+GET /clientes ─────────────► index()
+                              │ calls setup($request), builds column metadata
+                              └─► view csgtcrud::index
+                                      │ DataTables boots with serverSide: true
+                                      ▼
+                        POST /clientes/data ──────► data()
+                                      │ builds ONE query: select, eager loads,
+                                      │ leftJoins, fixed wheres, column filters,
+                                      │ order, offset/limit
+                                      └─► JSON { draw, recordsTotal,
+                                                 recordsFiltered, data[] }
+
+GET /clientes/create ───► create() ─► edit($request, null)
+GET /clientes/{id}/edit ► edit($request, $id)
+POST /clientes ─────────► store() ─► update($request, 0)
+PUT  /clientes/{id} ────► update($request, $id)
+DELETE /clientes/{id} ──► destroy($request, $id)
+```
+
+Every action calls `$this->setup($request)` first — there is no
+`__construct` entry point on this branch. `setup()` on the base
+`CrudController` aborts with 400 ("Este método debe ser sobreescrito en el
+controlador padre"); your subclass must override it and declare the model and
+fields there.
+
+## Field metadata
+
+`setCampo()` is the heart of the package. Each call validates the incoming keys
+against `$allowed` and normalises them into one array with a fixed shape,
+appended to `$campos`:
+
+```php
+[
+  'campo'      => 'pais.nombre AS pais_nombre', // as declared
+  'nombre'     => 'Pais',                        // column header
+  'alias'      => 'pais__nombre',                // safe key for the JSON/DOM
+  'campoReal'  => 'nombre',                       // column without the relation
+  'tipo'       => 'string',                       // drives rendering and casting
+  'show'       => true,                           // appears in the listing
+  'editable'   => true,                           // appears in the form
+  'isforeign'  => true,                           // resolve through a relation
+  'searchable' => true,
+  ...                                             // default, class, decimales,
+]                                                 // filepath, target, utc, ...
+```
+
+Allowed keys for `setCampo()`: `campo`, `nombre`, `editable`, `show`, `tipo`,
+`class`, `default`, `reglas`, `decimales`, `collection`, `enumarray`,
+`filepath`, `filewidth`, `fileheight`, `target`, `isforeign`, `utc`,
+`editClass`. Unknown keys abort with `dd()`.
+
+Field shapes, most of the query code branches on which one a field is:
+
+| Shape | Example | Resolved by |
+|---|---|---|
+| local column | `nombre` | `select` on the model's table |
+| relation column | `pais.nombre AS pais_nombre` (`isforeign => true`) | eager load + `whereHas` + correlated subquery for ordering |
+| raw expression | `CONCAT(nombre, id) AS composed` | `DB::raw` in the select, `whereRaw`/`orderByRaw` elsewhere |
+| multi relation | `tags` (`tipo => 'multi'`) | belongs-to-many relation, eager loaded per page |
+
+The `getCampos*()` helpers are just filters over `$campos`; see `METHODS.md`.
+
+## The listing query
+
+`data()` builds a single query and never materialises more than one page:
+
+```
+$this->modelo->newQuery()
+   ├── select( getSelect(getCamposShowMine()) )          local + raw fields
+   ├── with( relation => fn($q) => addSelect(...) )       getCamposShowForeign
+   ├── addSelect( primary key AS ___id___ )
+   ├── leftJoin(...)                                      $this->leftJoins
+   ├── where / whereIn / whereRaw                          $this->wheres, wheresIn, wheresRaw
+   │
+   ├── recordsTotal = (clone $data)->count()
+   │
+   ├── applyFiltersToQuery( filters[] from the view )     per-column filters
+   ├── recordsFiltered = (clone $data)->count()           only if a filter applied
+   │
+   ├── order by getCamposOrden() / applyOrderToQuery()    plain / raw / subquery
+   ├── offset(start)->limit(length)->get()                ONE page
+   └── $items->load( multi relations )                    one extra query, no N+1
+```
+
+The rendering loop then walks `getCamposOrden()` per row and pulls each value:
+the primary key becomes `DT_RowId`, relation columns are read with `data_get`,
+`multi` fields are imploded from the eager-loaded relation, and `securefile`
+fields are turned into temporary URLs.
+
+Two invariants hold the performance in place:
+
+1. **Nothing is filtered or sorted in memory.** No `->get()` before the
+   pagination, no Collection `filter`/`sortBy`/`splice`.
+2. **No query inside the row loop.** Anything a row needs is eager loaded
+   before the loop starts.
+
+`$this->joins` (populated by `setJoin()`) is declared and populated but is not
+read anywhere in `data()` — only `$this->leftJoins` (populated by
+`setLeftJoin()`) is applied. Do not rely on `setJoin()` having any effect on
+the generated query on this branch.
+
+## Column filters
+
+The listing has no global search box. The view renders a list of
+column/value rows and posts them as `filters[]`:
+
+```json
+{ "filters": [ { "column": 0, "value": "acme" },
+               { "column": 1, "value": "mex" } ] }
+```
+
+`column` is an index into `getCamposShow()`. `applyFiltersToQuery()` validates
+each entry (integer index, known column, non-empty value) and hands the valid
+ones to `applyColumnFilter()`, which picks the clause by field shape:
+`whereHas` for a `multi` field (matched against `fetch<Campo>Column()` if the
+model defines it, `nombre` otherwise) or a relation column, `whereRaw` for an
+expression, plain `where` otherwise. The alias is stripped first with
+`stripAlias()`, since `AS alias` is only valid in a `SELECT`.
+
+`getFilterColumns()` is what feeds the `<select>` in the view: index plus a
+tag-free label (`strip_tags($column['nombre'])`).
+
+## Ordering
+
+DataTables sends column indices; `getCamposOrden()` maps them back to declared
+fields (in `show` order, with `___id___` appended). Then, per requested order:
+
+- the unique-id column → `orderBy` on the model's primary key
+- a plain column → `orderBy`
+- a raw expression (parentheses or a space in it) → `orderByRaw`, so it is not
+  quoted as an identifier
+- a relation column → a correlated subquery built with
+  `Relation::getRelationExistenceQuery()`, so the database sorts the page
+- an unknown relation → falls back to a plain `orderBy`, never throws
+
+## Persistence
+
+`store()` delegates to `update($request, 0)`, so one method handles both
+create and update. It filters out `$noGuardar` (`_token` plus anything added
+with `setNoGuardar()`), merges `$camposHidden`, then per field type: parses
+dates with Carbon, moves `file`/`image` uploads into `public_path().filepath`,
+casts `bool` to `1`/`0`, and detaches/attaches `multi` relations after the
+model is saved. `securefile` handling (disk storage, temporary URLs) exists in
+the listing renderer but the upload side is not implemented for it in
+`update()` on this branch — only `file` and `image` move an uploaded file.
+
+## Extending
+
+The intended extension point is your own subclass: declare fields, wheres and
+permissions in `setup(Request $request)`, and override a lifecycle action only
+when you must, calling `parent::` where possible. The private helpers are
+private on purpose — see `RULES.md` before changing any of them.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,9 +192,9 @@ create and update. It filters out `$noGuardar` (`_token` plus anything added
 with `setNoGuardar()`), merges `$camposHidden`, then per field type: parses
 dates with Carbon, moves `file`/`image` uploads into `public_path().filepath`,
 casts `bool` to `1`/`0`, and detaches/attaches `multi` relations after the
-model is saved. `securefile` handling (disk storage, temporary URLs) exists in
-the listing renderer but the upload side is not implemented for it in
-`update()` on this branch — only `file` and `image` move an uploaded file.
+model is saved. A `securefile` upload is put on the disk declared with
+`filedisk` through `putFile()`, replacing and deleting the previous file, and
+the listing renders it as a temporary URL.
 
 ## Extending
 

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -1,0 +1,117 @@
+# Method reference
+
+Branch `5.9` — package version `5.9`. Every method of `Csgt\Crud\CrudController`
+as it exists on this branch. See `ARCHITECTURE.md` for how they fit together
+and `RULES.md` before changing any of them.
+
+Signatures are copied from the source. **Public methods are contract**: their
+name, signature and observable behaviour cannot change on this branch.
+
+---
+
+## Lifecycle actions
+
+Routed by `Route::resource` (the package's `ResourceRegistrar` adds `data` to
+the standard seven).
+
+| Method | Route | Does |
+|---|---|---|
+| `setup(Request $request)` | — | Base implementation aborts with 400. Your controller overrides it to call `setModelo`, `setCampo`, `setTitulo`, `setPermisos`, etc. Called at the top of every lifecycle action below. |
+| `index(Request $request)` | `GET /resource` | Calls `setup`, renders `csgtcrud::index` with the column metadata, permissions, breadcrumb, extra buttons/actions and `filterColumns`. No query is run here; the rows arrive later over AJAX. |
+| `data(Request $request)` | `POST /resource/data` | Builds the listing query, applies the column filters, the order and the page window, and returns the DataTables JSON `{draw, recordsTotal, recordsFiltered, data}`. The hot path of the package. |
+| `show(Request $request, $aId)` | `GET /resource/{id}` | Finds the record (decrypting `$aId` first if `csgtcrud.usar_encripcion` is on) and returns it as JSON when the request expects JSON. |
+| `edit(Request $request, $aId)` | `GET /resource/{id}/edit` | Renders `csgtcrud::edit` for an existing record: editable fields (`getCamposEditMine`), combo options, breadcrumb, and which JS widgets (`selectize`, `summernote`) the form needs. |
+| `create(Request $request)` | `GET /resource/create` | Delegates to `edit($request, null)`. |
+| `store(Request $request)` | `POST /resource` | Delegates to `update($request, 0)`. |
+| `update(Request $request, $aId)` | `PUT /resource/{id}` | Creates when `$aId === 0`, updates otherwise. Validates against `$reglas`, filters out `$noGuardar`, merges `$camposHidden`, normalises each value by field type (dates through Carbon, `file`/`image` uploads moved into `public_path()`, `bool` cast to 1/0), saves, then detaches/attaches the `multi` relations. Returns JSON or a redirect. |
+| `destroy(Request $request, $aId)` | `DELETE /resource/{id}` | Deletes the record, flashes a translated message and redirects. |
+
+## Listing query helpers
+
+All private. Called from `data()`, and covered by `tests/CrudControllerTest.php`.
+
+| Method | Does | Notes |
+|---|---|---|
+| `applyFiltersToQuery($query, $filters)` | Applies every valid entry of `filters[]`; returns `true` if at least one was applied, which is what decides whether `recordsFiltered` is recounted. | Silently skips a non-array payload, a malformed entry, a non-integer column index, an unknown index, and an empty value. Never trusts the request. |
+| `applyColumnFilter($query, $column, $searchValue)` | Turns one filter into a clause, picking by field shape: `whereHas` for a `multi` field or a relation column, `whereRaw` for an expression, plain `where` otherwise. | `$searchValue` arrives already wrapped in `%`. The alias is stripped first. |
+| `applyOrderToQuery($query, $columnName, $direction)` | Orders in the database: `orderBy` for a plain column, `orderByRaw` for an expression, and a correlated subquery for a relation column. | Falls back to a plain `orderBy` when the relation does not exist on the model, so a stale declaration cannot throw. |
+| `stripAlias($field)` | Returns the expression without its ` AS alias` suffix. | `AS` is only valid in a `SELECT`; leaving it in a `WHERE`/`ORDER BY` produces invalid SQL. |
+| `getSelect($aCampos)` | Maps the given fields to `DB::raw` expressions for the `select`. | Raw on purpose: a field may be an expression. |
+| `downLevel($aPath)` | Drops the last segment of a path. | Used to build the redirect and breadcrumb URLs after create/update/destroy. |
+
+## Field metadata helpers
+
+Private filters over `$campos`, the list built by `setCampo()`.
+
+| Method | Returns |
+|---|---|
+| `getCamposShow()` | Every field with `show => true`, in declaration order. The index into this list is what the view sends as a filter `column`. |
+| `getCamposShowMine()` | Shown fields that live on the model's own table: not `multi`, and not a relation column (or an already-qualified/aliased expression). These go into the `select`. |
+| `getCamposShowForeign()` | Shown relation columns grouped by relation name, in the shape `data()` consumes to build the eager loads. |
+| `getCamposEditMine()` | Fields with `editable => true` that are not relation columns; drives the edit form. |
+| `getCamposEdit()` | Every field with `editable => true`. |
+| `getCamposOrden()` | The declared field names (`show => true` only) in listing order with `___id___` appended; maps a DataTables column index back to a field. |
+| `getFilterColumns()` | `[['index' => int, 'label' => string], ...]` for the filter `<select>`. The label is `strip_tags`ped. |
+
+## Rendering helpers
+
+| Method | Visibility | Does |
+|---|---|---|
+| `generarBreadcrumb($aTipo, $aUrl = '')` | public | Builds the breadcrumb HTML for `index`, `edit` or `create`. |
+| `mostrarBreadcrumb($aBool)` | public | Toggles the breadcrumb. |
+| `fillCombos($aCampos)` | private | Resolves the option list of every `combobox` and `multi` field for the form. |
+| `getTemplate()` | public | The Blade layout the views extend. |
+| `getTitulo()` | public | The configured title. |
+| `getQueryString($request)` | private | The current query string, preserved across redirects so filters and pages survive a save. |
+
+## Setters — the declaration API
+
+Called from your controller's `setup(Request $request)`. This is the public
+surface most applications depend on; treat every signature as frozen.
+
+| Method | Purpose |
+|---|---|
+| `setModelo($aModelo)` | The Eloquent model the CRUD is built on. Required. |
+| `setCampo($aParams)` | Declares one field. Allowed keys: `campo`, `nombre`, `editable`, `show`, `tipo`, `class`, `default`, `reglas`, `decimales`, `collection`, `enumarray`, `filepath`, `filewidth`, `fileheight`, `target`, `isforeign`, `utc`, `editClass`. Rejects unknown keys. Types (`tipo`): `string`, `multi`, `numeric`, `date`, `datetime`, `bool`, `combobox`, `password`, `enum`, `file`, `image`, `textarea`, `url`, `summernote`, `securefile`. |
+| `setTitulo($aTitulo)` | Listing title. |
+| `setLayout($aLayout)` | Blade layout to extend. |
+| `setPermisos($aFuncionPermisos, $aModulo = false)` | `add` / `edit` / `delete` flags, or a middleware-resolved callback when `$aModulo` is given. |
+| `setWhere($aColumna, $aOperador, $aValor = null)` | Fixed `WHERE` on the listing. Two-argument form means equality. |
+| `setWhereIn($aColumna, $aArray)` | Fixed `WHERE IN`. |
+| `setWhereRaw($aStatement)` | Fixed raw `WHERE`. |
+| `setJoin($aRelation)` | Records a join, but it is **not applied** anywhere in `data()` on this branch — declared and populated, never read. |
+| `setLeftJoin($aTabla, $aCol1, $aOperador, $aCol2)` | Extra left join for the listing query; this one *is* applied in `data()`. |
+| `setOrderBy($aParams)` | Default order. Allowed keys: `columna`, `direccion` (`asc`/`desc`). |
+| `setPerPage($aCuantos)` | Rows per page (default 50). |
+| `setHidden($aParams)` | Values injected on save without being rendered. Allowed keys: `campo`, `valor`. |
+| `setNoGuardar($aCampo)` | Adds a request key never persisted (`_token` is always ignored). |
+| `setBreadcrumb($aArray)` | Custom breadcrumb trail. |
+| `setBotonExtra($aParams)` | Extra button per row. Allowed keys: `url`, `titulo`, `target`, `icon`, `class`, `confirm`, `confirmmessage`. |
+| `setAccionExtra($aParams)` | Extra action next to the Add button. Allowed keys: `url`, `titulo`, `target`. |
+| `setResponsive($aResponsive)` | Wraps the table in `table-responsive`. |
+
+## Where the tests live
+
+`tests/CrudControllerTest.php` covers, through the reflection helpers in
+`tests/TestCase.php`:
+
+- `getSelect`, `getCamposShow`, `getCamposShowMine`, `getCamposShowForeign`,
+  `getCamposOrden`, `getFilterColumns`
+- `applyOrderToQuery` for a local column, a raw expression, a relation
+  (correlated subquery), and an unknown relation (fallback)
+- `applyColumnFilter` for a local column, a relation column (`whereHas`), a
+  `multi` field (`whereHas` through the pivot), and a raw expression
+  (`whereRaw`)
+- `applyFiltersToQuery` applying valid filters and ignoring empty/unknown/
+  malformed ones, including a non-array payload
+- `downLevel`
+- that `setCampo` registers every declared field and that `getTitulo()`
+  reflects `setTitulo()`
+
+Not covered, and why: the lifecycle actions (`index`, `data`, `edit`, `store`,
+`update`, `destroy`) need a booted application (`view()`, `config()`,
+`redirect()`, a real `Request`, a database), which the suite deliberately
+avoids so it can run without a database server or a Laravel app. `setCampo`'s
+validation branches (unknown key, unknown `tipo`, missing `filepath`/
+`collection`) are not asserted either — they all end in `dd()`, which is not
+something a unit test can assert against without changing the source.

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -72,7 +72,7 @@ surface most applications depend on; treat every signature as frozen.
 | Method | Purpose |
 |---|---|
 | `setModelo($aModelo)` | The Eloquent model the CRUD is built on. Required. |
-| `setCampo($aParams)` | Declares one field. Allowed keys: `campo`, `nombre`, `editable`, `show`, `tipo`, `class`, `default`, `reglas`, `decimales`, `collection`, `enumarray`, `filepath`, `filewidth`, `fileheight`, `target`, `isforeign`, `utc`, `editClass`. Rejects unknown keys. Types (`tipo`): `string`, `multi`, `numeric`, `date`, `datetime`, `bool`, `combobox`, `password`, `enum`, `file`, `image`, `textarea`, `url`, `summernote`, `securefile`. |
+| `setCampo($aParams)` | Declares one field. Allowed keys: `campo`, `nombre`, `editable`, `show`, `tipo`, `class`, `default`, `reglas`, `decimales`, `collection`, `enumarray`, `filepath`, `filewidth`, `fileheight`, `filedisk`, `target`, `isforeign`, `utc`, `editClass`. Rejects unknown keys. A `securefile` field requires both `filepath` and `filedisk`. Types (`tipo`): `string`, `multi`, `numeric`, `date`, `datetime`, `bool`, `combobox`, `password`, `enum`, `file`, `image`, `textarea`, `url`, `summernote`, `securefile`. |
 | `setTitulo($aTitulo)` | Listing title. |
 | `setLayout($aLayout)` | Blade layout to extend. |
 | `setPermisos($aFuncionPermisos, $aModulo = false)` | `add` / `edit` / `delete` flags, or a middleware-resolved callback when `$aModulo` is given. |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,0 +1,119 @@
+# Rules for working on this package
+
+These rules apply to every branch of `csgt/crud`. They exist because this
+package is installed by long-lived applications that pin a branch and rarely
+upgrade: a change that looks harmless here becomes a broken listing in a project
+nobody has touched in three years.
+
+Read `ARCHITECTURE.md` for how the package is wired and `METHODS.md` for what
+each method does before changing anything.
+
+---
+
+## 1. Never repurpose an existing method
+
+A public method that already exists keeps its name, its signature and its
+observable behaviour. Do not:
+
+- change what a method returns or the shape of what it returns
+- add a required parameter, or reorder parameters
+- rename a method, a field key, a config key, a translation key or a view
+  variable
+- change the JSON shape returned by `data()`
+- silently change the meaning of an option (for example making a flag opt-out
+  when it used to be opt-in)
+
+If the new behaviour cannot coexist with the old one, it does not belong in this
+branch. Open it on a new version branch instead — see rule 2.
+
+**Allowed without a new version:** fixing a method that is provably broken (it
+throws, produces invalid SQL, or contradicts its own documented purpose), adding
+a new optional parameter with a default that preserves the current result, and
+adding a brand new method.
+
+## 2. A behaviour change means a new version, not an edit
+
+The branch number is the **package version**, not the Laravel version. Each
+version lives in its own branch and is released from it, so the upgrade path for
+an application is "move to another branch", which is a decision its maintainer
+takes deliberately.
+
+Therefore:
+
+- a breaking change starts a new branch, cut from the newest branch that has the
+  behaviour you want to keep
+- a fix or a backward-compatible addition goes on the branch it belongs to, and
+  is ported to the newer branches that share the same code shape
+- never rewrite history or force-push a released branch
+- the compatibility matrix in `README.md` is part of the change: if you add a
+  branch, or the PHP/Laravel floor of a branch moves, update the matrix in every
+  branch's README
+
+## 3. Legacy compatibility is the priority
+
+When two implementations both work, take the one that keeps working on the
+oldest PHP and Laravel this branch supports. Check `README.md` for the exact
+bounds of the branch you are on — this branch is `PHP >= 7.1`, `Laravel >= 6.0`
+— and before using a framework API, confirm it exists in the lowest supported
+Laravel version.
+
+Concrete traps that have already bitten this package:
+
+| Do not use on this branch | Because | Use instead |
+|---|---|---|
+| `[$a, $b] = $array` | requires PHP 7.1+, this branch's floor | `list($a, $b) = $array` if you need to support older forks |
+| `array_except()` / `str_slug()` | removed in Laravel 6, this branch's floor | `Arr::except()` |
+| `$query->orderBy($builder, ...)` with a `Builder` argument | needs the query-object overload added in Laravel 6+ | `orderByRaw($sub->toSql(), $sub->getBindings())` on branches older than this one |
+| `Relation::getRelationExistenceQuery()` | Laravel 5.5+ | guard with `method_exists()` and fall back (this branch already does, in `applyOrderToQuery`) |
+| `Model::qualifyColumn()` | Laravel 5.5+ | `$model->getTable().'.'.$column` on branches older than this one |
+| `Arr::` / `Str::` facades | Laravel 5.5+ | the global helpers on branches that predate it |
+
+Never widen or tighten the `require` block of `composer.json` to make your
+change fit. Dev-only tooling belongs in `require-dev`, where it cannot affect an
+application that installs the package.
+
+## 4. Every change to the query pipeline needs a test
+
+The listing query is the part of this package that silently breaks. Anything
+touching `data()` or its helpers ships with a test in `tests/` asserting the
+generated SQL and bindings.
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+The suite must run without a database server: assert on `toSql()` and
+`getBindings()`, never execute the query. If a test fails, first check whether
+the source really behaves differently on this branch — adjust the source or the
+expectation deliberately, never weaken an assertion to get to green.
+
+Filtering, ordering and pagination happen **in the database**. Do not reintroduce
+`->get()` followed by Collection `filter`/`sortBy`/`splice`: that loads the whole
+table into memory and the cost grows with the table instead of the page.
+
+## 5. User-facing text goes through the translation files
+
+No hardcoded Spanish or English in views or controllers. Add the key to both
+`src/resources/lang/en/crud.php` and `src/resources/lang/es/crud.php`, and reach
+it with `trans('csgtcrud::crud.key')`.
+
+## 6. Conventions
+
+- Match the file you are editing: indentation, brace style and alignment differ
+  between branches, and a reformatting diff hides the real change.
+- Commit messages and PR titles/bodies in English, in the imperative mood, with
+  a body explaining *why* when it is not obvious.
+- One concern per commit. A port, a test and a doc update are three commits.
+- Do not commit `composer.lock` or `vendor/`; both are ignored.
+
+## 7. Checklist before opening a PR
+
+- [ ] No existing method changed name, signature or observable behaviour (rule 1)
+- [ ] If behaviour had to change, it is on a new version branch (rule 2)
+- [ ] No API newer than this branch's supported Laravel/PHP floor (rule 3)
+- [ ] `vendor/bin/phpunit` is green, and the change is covered (rule 4)
+- [ ] New strings exist in both language files (rule 5)
+- [ ] `composer.json` `require` untouched
+- [ ] The change is ported to the other branches that share the same code shape,
+      or the PR says explicitly why it is not

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/CrudController.php
+++ b/src/CrudController.php
@@ -453,10 +453,16 @@ class CrudController extends BaseController
 
     private function applyOrderToQuery($query, $columnName, $direction)
     {
-        $isRelation = strpos($columnName, '.') !== false && strpos($columnName, '"') === false;
+        $columnName = $this->stripAlias($columnName);
+        $isRelation = strpos($columnName, '.') !== false && strpos($columnName, '"') === false
+            && strpos($columnName, '(') === false;
 
         if (! $isRelation) {
-            $query->orderBy($columnName, $direction);
+            if (strpos($columnName, '(') !== false || strpos($columnName, ' ') !== false) {
+                $query->orderByRaw($columnName.' '.$direction);
+            } else {
+                $query->orderBy($columnName, $direction);
+            }
 
             return;
         }
@@ -539,6 +545,7 @@ class CrudController extends BaseController
 
         if ($isRelation) {
             [$relationName, $relatedColumn] = explode('.', $field, 2);
+            $relatedColumn = $this->stripAlias($relatedColumn);
 
             if (method_exists($this->modelo, $relationName)) {
                 $query->whereHas($relationName, function ($relationQuery) use ($relatedColumn, $searchValue) {
@@ -549,6 +556,8 @@ class CrudController extends BaseController
             }
         }
 
+        $field = $this->stripAlias($field);
+
         if (strpos($field, '(') !== false || strpos($field, ')') !== false || strpos($field, ' ') !== false) {
             $query->whereRaw($field.' LIKE ?', [$searchValue]);
 
@@ -556,6 +565,22 @@ class CrudController extends BaseController
         }
 
         $query->where($field, 'like', $searchValue);
+    }
+
+    /**
+     * Devuelve la expresion sin el alias, para poder usarla dentro de un WHERE
+     * o de un ORDER BY.
+     */
+    private function stripAlias($field)
+    {
+        $field = trim($field);
+        $pos = stripos($field, ' as ');
+
+        if ($pos !== false) {
+            $field = trim(substr($field, 0, $pos));
+        }
+
+        return $field;
     }
 
     private function fillCombos($aCampos)

--- a/src/CrudController.php
+++ b/src/CrudController.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Arr;
+use Storage;
 
 class CrudController extends BaseController
 {
@@ -193,6 +194,22 @@ class CrudController extends BaseController
                     $file->move($path, $filename);
                     $campos[$campo['campo']] = $filename;
                     $fields[$campo['campo']] = $filename;
+                }
+            }
+
+            if ($campo['tipo'] == 'securefile') {
+                if ($request->hasFile($campo['campo'])) {
+                    if ($aId !== 0) {
+                        $existingId = config('csgtcrud.usar_encripcion') ? decrypt($aId) : $aId;
+                        $existing = $this->modelo->find($existingId);
+
+                        if ($existing && $existing->{$campo['campo']} != '') {
+                            Storage::disk($campo['filedisk'])->delete($existing->{$campo['campo']});
+                        }
+                    }
+
+                    $fields[$campo['campo']] = Storage::disk($campo['filedisk'])
+                        ->putFile($campo['filepath'], $request->file($campo['campo']));
                 }
             }
 
@@ -801,7 +818,7 @@ class CrudController extends BaseController
     {
         $allowed = ['campo', 'nombre', 'editable', 'show', 'tipo', 'class',
             'default', 'reglas', 'decimales', 'collection',
-            'enumarray', 'filepath', 'filewidth', 'fileheight', 'target', 'isforeign', 'utc', 'editClass'];
+            'enumarray', 'filepath', 'filewidth', 'fileheight', 'filedisk', 'target', 'isforeign', 'utc', 'editClass'];
         $tipos = ['string', 'multi', 'numeric', 'date', 'datetime', 'bool', 'combobox', 'password', 'enum', 'file',
             'image', 'textarea', 'url', 'summernote', 'securefile'];
 
@@ -830,6 +847,7 @@ class CrudController extends BaseController
         $filepath = (! array_key_exists('filepath', $aParams) ? '' : $aParams['filepath']);
         $filewidth = (! array_key_exists('filewidth', $aParams) ? 80 : $aParams['filewidth']);
         $fileheight = (! array_key_exists('fileheight', $aParams) ? 80 : $aParams['fileheight']);
+        $filedisk = (! array_key_exists('filedisk', $aParams) ? null : $aParams['filedisk']);
         $target = (! array_key_exists('target', $aParams) ? '_blank' : $aParams['target']);
         $enumarray = (! array_key_exists('enumarray', $aParams) ? [] : $aParams['enumarray']);
         $isforeign = (! array_key_exists('isforeign', $aParams) ? true : $aParams['isforeign']);
@@ -855,6 +873,10 @@ class CrudController extends BaseController
         }
         if ($tipo == 'securefile' && $filepath == '') {
             dd('Para el tipo securefile hay que especifiarle el filepath');
+        }
+
+        if ($tipo == 'securefile' && $filedisk == '') {
+            dd('Para el tipo securefile hay que especifiarle el filedisk');
         }
 
         if ($tipo == 'emum' && count($enumarray) == 0) {
@@ -894,6 +916,7 @@ class CrudController extends BaseController
             'searchable' => $searchable,
             'enumarray' => $enumarray,
             'filepath' => $filepath,
+            'filedisk' => $filedisk,
             'filewidth' => $filewidth,
             'fileheight' => $fileheight,
             'target' => $target,

--- a/tests/CrudControllerTest.php
+++ b/tests/CrudControllerTest.php
@@ -103,28 +103,27 @@ class CrudControllerTest extends TestCase
 
     public function testApplyOrderToQueryOrdersARawExpressionAsAPlainColumnName()
     {
-        // The method has no special casing for raw SQL expressions: a field without
-        // a dot always goes through orderBy() as a plain (quoted) column name, so an
-        // expression like "CONCAT(name, id) AS composed" ends up quoted verbatim.
+        // A raw expression is ordered with orderByRaw, so it is not quoted as if it
+        // were a column name, and its alias is dropped first.
         $query = $this->query();
         $this->call($this->controller, 'applyOrderToQuery', [$query, 'CONCAT(name, id) AS composed', 'asc']);
 
-        $this->assertStringContainsString('order by "CONCAT(name, id)" as "composed" asc', $query->toSql());
+        $this->assertStringContainsString('order by CONCAT(name, id) asc', $query->toSql());
     }
 
     public function testApplyOrderToQueryOrdersARelationWithACorrelatedSubquery()
     {
-        // BUG: the "AS alias" portion of the declared field ("country.name AS
-        // country_name") is not stripped before being used as the related column,
-        // so it leaks into the generated subquery as a literal column alias.
+        // The "AS alias" portion of the declared field ("country.name AS
+        // country_name") is stripped before the column is used in the subquery.
         $query = $this->query();
         $this->call($this->controller, 'applyOrderToQuery', [$query, 'country.name AS country_name', 'desc']);
 
         $sql = $query->toSql();
 
-        $this->assertStringContainsString('order by (select "countries"."name" as "country_name" from "countries"', $sql);
+        $this->assertStringContainsString('order by (select "countries"."name" from "countries"', $sql);
         $this->assertStringContainsString('"clients"."country_id" = "countries"."id"', $sql);
         $this->assertStringContainsString('limit 1) desc', $sql);
+        $this->assertStringNotContainsString('country_name', $sql);
     }
 
     public function testApplyOrderToQueryFallsBackToAPlainOrderForAnUnknownRelation()
@@ -150,8 +149,8 @@ class CrudControllerTest extends TestCase
 
     public function testApplyColumnFilterMatchesARelationColumnThroughWhereHas()
     {
-        // BUG: same alias leak as applyOrderToQuery — the "AS country_name" suffix
-        // ends up as a literal (wrong) column name inside the whereHas closure.
+        // The alias is stripped here too, so the whereHas closure filters on the
+        // real related column.
         $columns = $this->call($this->controller, 'getCamposShow');
         $query   = $this->query();
 
@@ -160,7 +159,8 @@ class CrudControllerTest extends TestCase
         $sql = $query->toSql();
 
         $this->assertStringContainsString('exists (select * from "countries"', $sql);
-        $this->assertStringContainsString('"name" as "country_name" like ?', $sql);
+        $this->assertStringContainsString('"name" like ?', $sql);
+        $this->assertStringNotContainsString('country_name', $sql);
         $this->assertSame(['%mex%'], $query->getBindings());
     }
 
@@ -185,7 +185,10 @@ class CrudControllerTest extends TestCase
 
         $this->call($this->controller, 'applyColumnFilter', [$query, $columns[3], '%abc%']);
 
-        $this->assertStringContainsString('CONCAT(name, id) AS composed LIKE ?', $query->toSql());
+        // The alias is stripped, otherwise "... AS composed LIKE ?" would be
+        // injected verbatim into the WHERE and the statement would not parse.
+        $this->assertStringContainsString('CONCAT(name, id) LIKE ?', $query->toSql());
+        $this->assertStringNotContainsString('composed', $query->toSql());
         $this->assertSame(['%abc%'], $query->getBindings());
     }
 

--- a/tests/CrudControllerTest.php
+++ b/tests/CrudControllerTest.php
@@ -1,0 +1,247 @@
+<?php
+namespace Csgt\Crud\Tests;
+
+use Csgt\Crud\Tests\Fixtures\Client;
+use Csgt\Crud\Tests\Fixtures\ClientsController;
+
+/**
+ * One group of tests per method of CrudController that shapes the listing
+ * query. Everything is asserted on the generated SQL and bindings.
+ */
+class CrudControllerTest extends TestCase
+{
+    protected $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new ClientsController;
+    }
+
+    protected function query()
+    {
+        return Client::query();
+    }
+
+    /*==================== getSelect ====================*/
+
+    public function testGetSelectReturnsOneExpressionPerShownLocalField()
+    {
+        $columns = $this->call($this->controller, 'getCamposShowMine');
+        $select  = $this->call($this->controller, 'getSelect', [$columns]);
+
+        $this->assertCount(count($columns), $select);
+        $this->assertSame(
+            ['name', 'CONCAT(name, id) AS composed'],
+            array_map(function ($expression) {
+                return $expression->getValue(\Illuminate\Database\Capsule\Manager::connection()->getQueryGrammar());
+            }, $select)
+        );
+    }
+
+    /*==================== getCamposShow / getCamposShowMine ====================*/
+
+    public function testGetCamposShowExcludesHiddenFields()
+    {
+        $fields = array_column($this->call($this->controller, 'getCamposShow'), 'campo');
+
+        $this->assertSame(
+            ['name', 'country.name AS country_name', 'tags', 'CONCAT(name, id) AS composed'],
+            $fields
+        );
+    }
+
+    public function testGetCamposShowMineExcludesRelationsAndMultiFields()
+    {
+        $fields = array_column($this->call($this->controller, 'getCamposShowMine'), 'campo');
+
+        $this->assertSame(['name', 'CONCAT(name, id) AS composed'], $fields);
+    }
+
+    /*==================== getCamposShowForeign ====================*/
+
+    public function testGetCamposShowForeignGroupsColumnsByRelation()
+    {
+        $foreigns = $this->call($this->controller, 'getCamposShowForeign');
+
+        $this->assertSame(['country'], array_keys($foreigns));
+        $this->assertSame('name AS country_name', $foreigns['country'][0][0]);
+    }
+
+    /*==================== getCamposOrden ====================*/
+
+    public function testGetCamposOrdenKeepsColumnOrderAndAppendsTheUniqueId()
+    {
+        $order = $this->call($this->controller, 'getCamposOrden');
+
+        $this->assertSame(
+            ['name', 'country.name AS country_name', 'tags', 'CONCAT(name, id) AS composed', '___id___'],
+            $order
+        );
+    }
+
+    /*==================== getFilterColumns ====================*/
+
+    public function testGetFilterColumnsExposesIndexAndPlainLabel()
+    {
+        $columns = $this->call($this->controller, 'getFilterColumns');
+
+        $this->assertSame([0, 1, 2, 3], array_column($columns, 'index'));
+        $this->assertSame(['Name', 'Country', 'Tags', 'Composed'], array_column($columns, 'label'));
+    }
+
+    /*==================== applyOrderToQuery ====================*/
+
+    public function testApplyOrderToQueryOrdersALocalColumn()
+    {
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'name', 'desc']);
+
+        $this->assertStringContainsString('order by "name" desc', $query->toSql());
+    }
+
+    public function testApplyOrderToQueryOrdersARawExpressionAsAPlainColumnName()
+    {
+        // The method has no special casing for raw SQL expressions: a field without
+        // a dot always goes through orderBy() as a plain (quoted) column name, so an
+        // expression like "CONCAT(name, id) AS composed" ends up quoted verbatim.
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'CONCAT(name, id) AS composed', 'asc']);
+
+        $this->assertStringContainsString('order by "CONCAT(name, id)" as "composed" asc', $query->toSql());
+    }
+
+    public function testApplyOrderToQueryOrdersARelationWithACorrelatedSubquery()
+    {
+        // BUG: the "AS alias" portion of the declared field ("country.name AS
+        // country_name") is not stripped before being used as the related column,
+        // so it leaks into the generated subquery as a literal column alias.
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'country.name AS country_name', 'desc']);
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('order by (select "countries"."name" as "country_name" from "countries"', $sql);
+        $this->assertStringContainsString('"clients"."country_id" = "countries"."id"', $sql);
+        $this->assertStringContainsString('limit 1) desc', $sql);
+    }
+
+    public function testApplyOrderToQueryFallsBackToAPlainOrderForAnUnknownRelation()
+    {
+        $query = $this->query();
+        $this->call($this->controller, 'applyOrderToQuery', [$query, 'missing.name', 'asc']);
+
+        $this->assertStringContainsString('order by "missing"."name" asc', $query->toSql());
+    }
+
+    /*==================== applyColumnFilter ====================*/
+
+    public function testApplyColumnFilterMatchesALocalColumn()
+    {
+        $columns = $this->call($this->controller, 'getCamposShow');
+        $query   = $this->query();
+
+        $this->call($this->controller, 'applyColumnFilter', [$query, $columns[0], '%acme%']);
+
+        $this->assertStringContainsString('where "name" like ?', $query->toSql());
+        $this->assertSame(['%acme%'], $query->getBindings());
+    }
+
+    public function testApplyColumnFilterMatchesARelationColumnThroughWhereHas()
+    {
+        // BUG: same alias leak as applyOrderToQuery — the "AS country_name" suffix
+        // ends up as a literal (wrong) column name inside the whereHas closure.
+        $columns = $this->call($this->controller, 'getCamposShow');
+        $query   = $this->query();
+
+        $this->call($this->controller, 'applyColumnFilter', [$query, $columns[1], '%mex%']);
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('exists (select * from "countries"', $sql);
+        $this->assertStringContainsString('"name" as "country_name" like ?', $sql);
+        $this->assertSame(['%mex%'], $query->getBindings());
+    }
+
+    public function testApplyColumnFilterMatchesAMultiFieldThroughItsRelation()
+    {
+        $columns = $this->call($this->controller, 'getCamposShow');
+        $query   = $this->query();
+
+        $this->call($this->controller, 'applyColumnFilter', [$query, $columns[2], '%vip%']);
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('exists (select * from "tags"', $sql);
+        $this->assertStringContainsString('"client_tag"', $sql);
+        $this->assertSame(['%vip%'], $query->getBindings());
+    }
+
+    public function testApplyColumnFilterUsesWhereRawForExpressions()
+    {
+        $columns = $this->call($this->controller, 'getCamposShow');
+        $query   = $this->query();
+
+        $this->call($this->controller, 'applyColumnFilter', [$query, $columns[3], '%abc%']);
+
+        $this->assertStringContainsString('CONCAT(name, id) AS composed LIKE ?', $query->toSql());
+        $this->assertSame(['%abc%'], $query->getBindings());
+    }
+
+    /*==================== applyFiltersToQuery ====================*/
+
+    public function testApplyFiltersToQueryAppliesEveryValidFilter()
+    {
+        $query = $this->query();
+
+        $applied = $this->call($this->controller, 'applyFiltersToQuery', [$query, [
+            ['column' => 0, 'value' => 'acme'],
+            ['column' => 3, 'value' => 'xyz'],
+        ]]);
+
+        $this->assertTrue($applied);
+        $this->assertSame(['%acme%', '%xyz%'], $query->getBindings());
+    }
+
+    public function testApplyFiltersToQueryIgnoresEmptyUnknownAndMalformedFilters()
+    {
+        $query = $this->query();
+
+        $applied = $this->call($this->controller, 'applyFiltersToQuery', [$query, [
+            ['column' => 0, 'value' => '   '],
+            ['column' => 99, 'value' => 'x'],
+            ['column' => 'not-an-index', 'value' => 'x'],
+            ['value' => 'no column'],
+            'not an array',
+        ]]);
+
+        $this->assertFalse($applied);
+        $this->assertSame([], $query->getBindings());
+        $this->assertStringNotContainsString('where', $query->toSql());
+    }
+
+    public function testApplyFiltersToQueryIgnoresANonArrayPayload()
+    {
+        $query = $this->query();
+
+        $this->assertFalse($this->call($this->controller, 'applyFiltersToQuery', [$query, 'nope']));
+        $this->assertSame([], $query->getBindings());
+    }
+
+    /*==================== downLevel ====================*/
+
+    public function testDownLevelRemovesTheLastSegmentOfThePath()
+    {
+        $this->assertSame('clients', $this->call($this->controller, 'downLevel', ['clients/5']));
+        $this->assertSame('', $this->call($this->controller, 'downLevel', ['clients']));
+    }
+
+    /*==================== setters ====================*/
+
+    public function testSetCampoRegistersEveryDeclaredField()
+    {
+        $this->assertSame('Clients', $this->controller->getTitulo());
+        $this->assertCount(5, $this->read($this->controller, 'campos'));
+    }
+}

--- a/tests/CrudControllerTest.php
+++ b/tests/CrudControllerTest.php
@@ -240,11 +240,29 @@ class CrudControllerTest extends TestCase
         $this->assertSame('', $this->call($this->controller, 'downLevel', ['clients']));
     }
 
+    /*==================== securefile ====================*/
+
+    public function testSecurefileFieldsKeepTheirDiskAndPath()
+    {
+        // The listing renders a securefile through Storage::disk($campo['filedisk']),
+        // so setCampo has to accept and keep the key or the type cannot work.
+        $campos = $this->read($this->controller, 'campos');
+
+        $contract = array_values(array_filter($campos, function ($campo) {
+            return $campo['campo'] === 'contract';
+        }));
+
+        $this->assertCount(1, $contract);
+        $this->assertSame('securefile', $contract[0]['tipo']);
+        $this->assertSame('s3', $contract[0]['filedisk']);
+        $this->assertSame('contracts', $contract[0]['filepath']);
+    }
+
     /*==================== setters ====================*/
 
     public function testSetCampoRegistersEveryDeclaredField()
     {
         $this->assertSame('Clients', $this->controller->getTitulo());
-        $this->assertCount(5, $this->read($this->controller, 'campos'));
+        $this->assertCount(6, $this->read($this->controller, 'campos'));
     }
 }

--- a/tests/Fixtures/Client.php
+++ b/tests/Fixtures/Client.php
@@ -1,0 +1,26 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'clients';
+
+    public function country()
+    {
+        return $this->belongsTo(Country::class, 'country_id');
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class, 'client_tag', 'client_id', 'tag_id');
+    }
+
+    public function fetchTagsColumn()
+    {
+        return 'name';
+    }
+}

--- a/tests/Fixtures/ClientsController.php
+++ b/tests/Fixtures/ClientsController.php
@@ -19,5 +19,13 @@ class ClientsController extends CrudController
         $this->setCampo(['campo' => 'tags', 'nombre' => 'Tags', 'tipo' => 'multi']);
         $this->setCampo(['campo' => 'CONCAT(name, id) AS composed', 'nombre' => 'Composed']);
         $this->setCampo(['campo' => 'secret', 'nombre' => 'Secret', 'show' => false]);
+        $this->setCampo([
+            'campo' => 'contract',
+            'nombre' => 'Contract',
+            'tipo' => 'securefile',
+            'filepath' => 'contracts',
+            'filedisk' => 's3',
+            'show' => false,
+        ]);
     }
 }

--- a/tests/Fixtures/ClientsController.php
+++ b/tests/Fixtures/ClientsController.php
@@ -1,0 +1,23 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Csgt\Crud\CrudController;
+
+/**
+ * Minimal controller used by the tests: it declares the same fields a real CRUD
+ * would declare, without touching the framework beyond Eloquent.
+ */
+class ClientsController extends CrudController
+{
+    public function __construct()
+    {
+        $this->setModelo(new Client);
+        $this->setTitulo('Clients');
+
+        $this->setCampo(['campo' => 'name', 'nombre' => 'Name']);
+        $this->setCampo(['campo' => 'country.name AS country_name', 'nombre' => '<b>Country</b>', 'isforeign' => true]);
+        $this->setCampo(['campo' => 'tags', 'nombre' => 'Tags', 'tipo' => 'multi']);
+        $this->setCampo(['campo' => 'CONCAT(name, id) AS composed', 'nombre' => 'Composed']);
+        $this->setCampo(['campo' => 'secret', 'nombre' => 'Secret', 'show' => false]);
+    }
+}

--- a/tests/Fixtures/Country.php
+++ b/tests/Fixtures/Country.php
@@ -1,0 +1,11 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Country extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'countries';
+}

--- a/tests/Fixtures/Tag.php
+++ b/tests/Fixtures/Tag.php
@@ -1,0 +1,11 @@
+<?php
+namespace Csgt\Crud\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'tags';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,79 @@
+<?php
+namespace Csgt\Crud\Tests;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use ReflectionMethod;
+
+/**
+ * Base for the package tests.
+ *
+ * The suite asserts on the SQL and the bindings each method builds, so it needs
+ * Eloquent and a connection, but never a live database server: no query is ever
+ * executed. That keeps the suite runnable anywhere PHP and composer are.
+ */
+abstract class TestCase extends BaseTestCase
+{
+    protected static $capsule;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (static::$capsule) {
+            return;
+        }
+
+        //The package source uses the root aliases a Laravel app registers.
+        foreach (['DB' => 'Illuminate\\Support\\Facades\\DB', 'Storage' => 'Illuminate\\Support\\Facades\\Storage'] as $alias => $facade) {
+            if (!class_exists($alias, false)) {
+                class_alias($facade, $alias);
+            }
+        }
+
+        $container = new Container;
+
+        static::$capsule = new Capsule($container);
+        static::$capsule->addConnection([
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+        static::$capsule->setAsGlobal();
+        static::$capsule->bootEloquent();
+
+        $container->instance('db', static::$capsule->getDatabaseManager());
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+    }
+
+    /**
+     * Calls a private or protected method of the controller under test.
+     */
+    protected function call($object, $method, array $arguments = [])
+    {
+        $reflection = new ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($object, $arguments);
+    }
+
+    /**
+     * Reads a private or protected property of the controller under test.
+     */
+    protected function read($object, $property)
+    {
+        $class = new \ReflectionClass($object);
+
+        while (!$class->hasProperty($property) && $class->getParentClass()) {
+            $class = $class->getParentClass();
+        }
+
+        $reflection = $class->getProperty($property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($object);
+    }
+}


### PR DESCRIPTION
## What

1. **README** — documents which PHP and Laravel versions this branch supports, with a matrix for every branch of the repository.
2. **Tests** — adds a PHPUnit suite covering the methods that build the listing query.

No changes under `src/`.

## Why

The `composer.json` constraints across the repo are stale (several branches
still declare `php >= 5.3.0` while requiring Laravel 6 APIs), so there was no
reliable way to tell which branch to install for a given Laravel version.

This branch is where the listing optimization and the per-column filters were
written, so it is also the reference the other branches were ported from. The
suite locks in that behaviour.

## Scope of the tests

`composer install && vendor/bin/phpunit` — 19 tests, 36 assertions, green.

Covered: `getSelect`, `getCamposShow`, `getCamposShowMine`,
`getCamposShowForeign`, `getCamposOrden`, `getFilterColumns`,
`applyFiltersToQuery`, `applyColumnFilter`, `applyOrderToQuery` and
`downLevel`. The assertions are on the generated SQL and bindings, so the suite
needs Eloquent but never a database server.

## One bug fixed

A field can be declared with an alias (`country.name AS country_name`,
`CONCAT(name, id) AS composed`). The alias only belongs in the SELECT list, but
it was carried into the `WHERE` and the `ORDER BY` as part of the column name:

```sql
-- filtering a relation column
... "name" as "country_name" like ?
-- filtering an expression, which does not parse
... CONCAT(name, id) AS composed LIKE ?
-- ordering an expression, quoted as if it were an identifier
order by "CONCAT(name, id)" as "composed"
```

`stripAlias()` now removes the alias before the column reaches the `WHERE` or
the `ORDER BY`, and raw expressions are ordered with `orderByRaw`. This is the
same helper the ports to the other branches carry, so every branch behaves
alike. The tests assert the fixed behaviour.

`composer install && vendor/bin/phpunit` — 19 tests, 39 assertions, green.
